### PR TITLE
deploy workflows

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,20 @@
+name: Deploy to Prod
+
+on:
+  release:
+    types:
+      - released
+
+concurrency:
+  group: prod
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Prod
+    uses: ./.github/workflows/deploy.yml
+    with:
+      env: prod
+      # the release name
+      version-name: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -1,0 +1,26 @@
+name: Deploy to Sandbox
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - synchronize
+      - labeled
+
+env:
+  # for workflow_dispatch: "branch:$name" or "tag:$name"
+  # for PRs with the deploy-to-sandbox tag: "pr:$number"
+  version_name: "${{ github.event_name == 'workflow_dispatch' && format('{0}:{1}', github.ref_type, github.ref_name) }}${{ github.event_name == 'pull_request' && format('pr:{0}', github.event.pull_request.number) }}"
+
+jobs:
+  deploy:
+    name: Deploy to Sandbox
+    concurrency:
+      group: sandbox
+      cancel-in-progress: true
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'deploy-to-sandbox') }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      env: sandbox
+      version-name: ${{ env.version_name }}
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,23 @@
+name: Deploy to Staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+concurrency:
+  group: staging
+  cancel-in-progress: true
+
+env:
+  # "branch:$name" or "tag:$name", except for the automatic deploys from pushing to main it's just "main".
+  version_name: "${{ (github.event_name == 'push' && github.ref_name == 'main' && 'main') || format('{0}:{1}', github.ref_type, github.ref_name) }}
+
+jobs:
+  deploy:
+    name: Deploy to Staging
+    uses: ./.github/workflows/deploy.yml
+    with:
+      env: staging
+      version-name: ${{ env.version_name }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ on:
     secrets:
       AWS_ROLE_ARN:
         required: true
+      DOCKER_REPO:
+        required: true
       SLACK_WEBHOOK:
         required: true
 
@@ -35,7 +37,7 @@ jobs:
       - name: Get versions
         id: calc-version
         run: |
-          docker_repo=orbit
+          docker_repo="${{ secrets.DOCKER_REPO }}"
           git_hash="$(git rev-parse --short HEAD)"
           version_id="${{ inputs.version-name }}:$git_hash"
           git_hash_tag="$docker_repo:git-$git_hash"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+on:
+  workflow_call:
+    inputs:
+      env:
+        required: true
+        type: string
+      version-name:
+        required: true
+        type: string
+        description: descriptive id of what's deployed (e.g. release name or pr number). doesn't have to be unique, the git hash is appended later
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
+      SLACK_WEBHOOK:
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.env }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: ${{ inputs.env }}
+
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get versions
+        id: calc-version
+        run: |
+          docker_repo=orbit
+          git_hash="$(git rev-parse --short HEAD)"
+          version_id="${{ inputs.version-name }}:$git_hash"
+          git_hash_tag="$docker_repo:git-$git_hash"
+          latest_env_tag="$docker_repo:latest-${{ inputs.env }}"
+          version_tag=$docker_repo:"$version_id"
+          echo "version-id=$version_id" | tee -a $GITHUB_OUTPUT
+          echo "deploy-tag=$version_tag" | tee -a $GITHUB_OUTPUT
+          printf "tag-list=%s,%s,%s\n" "$git_hash_tag" "$latest_env_tag" "$version_tag" | tee -a $GITHUB_OUTPUT
+      - uses: aws-actions/amazon-ecr-login@v2
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          cache-from: type=gha
+          tags: ${{ steps.calc-version.outputs.tag-list }}
+          push: true
+      - uses: mbta/actions/deploy-ecs@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          ecs-cluster: orbit
+          ecs-service: orbit-${{ inputs.env }}
+          docker-tag: ${{ steps.calc-version.outputs.deploy-tag }}
+      - uses: mbta/actions/notify-slack-deploy@v2
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}
+          custom-message: Deployed ${{ steps.calc-version.outputs.version-id }} to ${{ inputs.env }}


### PR DESCRIPTION
So this is ready for whenever infrastructure exists.

I don't have a way to test it yet.

Major differences from Glides deploy scripts:
- I've removed any reference to sentry (and a couple other things), since it doesn't exist yet.
- version-name is required in all envs. `version_id` is now a descriptive name that we can use for many purposes, including docker tags and sentry releases. It'll look like `2024-03-07:abc123` or `pr:1:abc123` or `main:abc123`, including the git hash.