### PR TITLE
ci: format deploy workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   # "branch:$name" or "tag:$name", except for the automatic deploys from pushing to main it's just "main".
-  version_name: "${{ (github.event_name == 'push' && github.ref_name == 'main' && 'main') || format('{0}:{1}', github.ref_type, github.ref_name) }}
+  version_name: "${{ (github.event_name == 'push' && github.ref_name == 'main' && 'main') || format('{0}:{1}', github.ref_type, github.ref_name) }}"
 
 jobs:
   deploy:


### PR DESCRIPTION
Asana Task: None

Bad merge conflict between deploy workflow which had a formatting/syntax error, and the commit that added the formatting check to CI now makes CI fail on main.

This does not check that the deploy workflow actually works, it just unbreaks CI.
If nobody's gonna do anything with Orbit soon, it'd be okay to wait to merge this until we actually get a chance to test deploys later this week.
If somebody does need CI to pass, then we can merge this PR.

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
