### PR TITLE
fix: standardize on credo strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
       - name: Credo
-        run: mix credo --strict
+        run: mix credo
       - name: Check formatting
         run: mix format --check-formatted
       - name: Run tests

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -46,7 +46,7 @@
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
       #
-      strict: false,
+      strict: true,
       #
       # To modify the timeout for parsing files, change this value:
       #


### PR DESCRIPTION
Asana Task: None

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

`credo`s line in our `test_all` task doesn't have `--strict`, but the CI action does. Let's remove what's in the CI action and rely on `.credo.exs` for strict=true.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
