### PR TITLE
log format in prod

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -21,6 +21,10 @@ config :orbit, OrbitWeb.Endpoint,
 
 config :logger, level: :info
 
+config :logger, :console,
+  format: "$time [$level] node=$node $metadata$message\n",
+  metadata: [:request_id, :remote_ip]
+
 config :ehmon, :report_mf, {:ehmon, :info_report}
 
 # diskusage_logger calls disksup,


### PR DESCRIPTION
Asana Task: [Other basic backend infrastructure required to build a basic HR Glides app](https://app.asana.com/0/1200689710863995/1206604030470719/f)

I noticed this when putting together the [Splunk dashboard](https://mbta.splunkcloud.com/en-US/app/search/orbit). Glides uses this log format, and specifically the `node` field, to count instances and group logs by instance.

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed