### PR TITLE
fix: fix Sobelow errors and make it actually fail CI

### DIFF
--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,4 +1,5 @@
 [
   format: "compact",
-  ignore: ["Config.HTTPS"],
+  ignore: ["Config.HTTPS", "Traversal.FileModule"],
+  exit: "low",
 ]

--- a/lib/orbit_web/router.ex
+++ b/lib/orbit_web/router.ex
@@ -16,6 +16,7 @@ defmodule OrbitWeb.Router do
   end
 
   pipeline :accepts_html do
+    plug :browser
     plug :accepts, ["html"]
     plug :put_root_layout, html: {OrbitWeb.Layouts, :root}
     # assigns used in the root layout
@@ -32,7 +33,6 @@ defmodule OrbitWeb.Router do
   end
 
   scope "/", OrbitWeb do
-    pipe_through :browser
     pipe_through :accepts_html
 
     get("/login", AuthController, :login_page)
@@ -41,7 +41,6 @@ defmodule OrbitWeb.Router do
   end
 
   scope "/", OrbitWeb do
-    pipe_through :browser
     pipe_through :accepts_html
     pipe_through :authenticated
 
@@ -68,7 +67,6 @@ defmodule OrbitWeb.Router do
     import Phoenix.LiveDashboard.Router
 
     scope "/dev" do
-      pipe_through :browser
       pipe_through :accepts_html
       pipe_through :authenticated
 


### PR DESCRIPTION
Asana Task: no PR, just ad-hoc.

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

I realized that we didn't actually have Sobelow set up such that warnings resulted in CI failures, and we had accumulated some warnings. For the directory traversal thing I think it's best to just turn that one off, but for the secure headers thing I refactored `router.ex` a bit so that the `:accepts_html` plug just calls the `:browser` plug directly to make it clearer that the former is only used when the latter is as well.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(X)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
