### PR TITLE
feat: Show operator sign in modal with operator info

### DIFF
--- a/js/components/operatorSignIn/attestation.tsx
+++ b/js/components/operatorSignIn/attestation.tsx
@@ -1,0 +1,59 @@
+import { findEmployeeByBadge, useEmployees } from "../../hooks/useEmployees";
+import { useSignInText } from "./text";
+import { ReactElement } from "react";
+
+export const Attestation = ({
+  badge,
+  onComplete,
+}: {
+  badge: string;
+  onComplete: () => void;
+}): ReactElement => {
+  const employees = useEmployees();
+  if (employees.status === "loading") {
+    return <div>Loading...</div>;
+  } else if (employees.status === "error") {
+    return <div>Unable to download employee data. Please try again.</div>;
+  }
+  const employee = findEmployeeByBadge(employees.result, badge);
+  const name =
+    employee !== undefined ?
+      `${employee.preferred_first ?? employee.first_name} ${employee.last_name}`
+    : `Operator #${badge}`;
+  return (
+    <>
+      Step 2 of 2
+      <SignInText />
+      <SignaturePrompt name={name} />
+      <button
+        className="w-full bg-mbta-blue text-gray-100 rounded-md mb-4"
+        onClick={onComplete}
+      >
+        Complete Fit for Duty Check
+      </button>
+    </>
+  );
+};
+
+export const SignInText = (): ReactElement => {
+  const signInText = useSignInText();
+  return <div>{signInText.text}</div>;
+};
+
+export const SignaturePrompt = ({ name }: { name: string }): ReactElement => {
+  return (
+    <div>
+      <label className="text-sm font-semibold">
+        <span className="text-xs font-semibold">Operator Badge Number</span>
+        <span className="absolute right-1 text-xxs font-semibold uppercase tracking-wide-4">
+          Required
+        </span>
+        <input type="text" className="w-full" inputMode="numeric" required />
+      </label>
+      <p className="mx-4 my-8">
+        By pressing the button below I, <b className="fs-mask">{name}</b>,
+        confirm the above is true.
+      </p>
+    </div>
+  );
+};

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -1,12 +1,17 @@
 import { className } from "../../util/dom";
-import { ReactElement, useId } from "react";
+import { ReactElement, useId, useState } from "react";
 
 export const OperatorSelection = ({
   nfcSupported: nfcSupported,
+  onOK,
 }: {
   nfcSupported: boolean;
+  onOK: (badge: string) => void;
 }): ReactElement => {
   const inputId = useId();
+  const [badgeEntry, setBadgeEntry] = useState<string>("");
+
+  const buttonEnabled = badgeEntry !== "";
 
   return (
     <div className="flex flex-col content-stretch">
@@ -15,7 +20,24 @@ export const OperatorSelection = ({
       : <NfcUnsupported />}
       <Or />
       <label htmlFor={inputId}>Search for an Operator</label>
-      <input id={inputId} />
+      <input
+        id={inputId}
+        onChange={(evt) => {
+          setBadgeEntry(evt.target.value);
+        }}
+      />
+      <button
+        disabled={!buttonEnabled}
+        onClick={() => {
+          onOK(badgeEntry);
+        }}
+        className={className([
+          "rounded bg-mbta-blue text-gray-200 mt-3 w-1/4 mx-auto",
+          !buttonEnabled && "opacity-50",
+        ])}
+      >
+        OK
+      </button>
     </div>
   );
 };

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -16,12 +16,7 @@ export const OperatorSignInModal = (): ReactElement => {
       }}
     >
       {badge === null ?
-        <OperatorSelection
-          nfcSupported={true}
-          onOK={(badge: string) => {
-            setBadge(badge);
-          }}
-        />
+        <OperatorSelection nfcSupported={true} onOK={setBadge} />
       : <Attestation
           badge={badge}
           onComplete={() => {

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -1,9 +1,11 @@
 import { Modal } from "../modal";
+import { Attestation } from "./attestation";
 import { OperatorSelection } from "./operatorSelection";
 import { ReactElement, useState } from "react";
 
 export const OperatorSignInModal = (): ReactElement => {
   const [show, setShow] = useState<boolean>(true);
+  const [badge, setBadge] = useState<string | null>(null);
 
   return (
     <Modal
@@ -13,7 +15,20 @@ export const OperatorSignInModal = (): ReactElement => {
         setShow(false);
       }}
     >
-      <OperatorSelection nfcSupported={true} />
+      {badge === null ?
+        <OperatorSelection
+          nfcSupported={true}
+          onOK={(badge: string) => {
+            setBadge(badge);
+          }}
+        />
+      : <Attestation
+          badge={badge}
+          onComplete={() => {
+            alert("Clicked!");
+          }}
+        />
+      }
     </Modal>
   );
 };

--- a/js/components/operatorSignIn/text.tsx
+++ b/js/components/operatorSignIn/text.tsx
@@ -6,9 +6,8 @@ export const useSignInText = (): {
   version: number;
   text: ReactElement;
 } => {
-  // Check the time only once on mount so that the text doesn't change if the time changes.
   return {
-    version: 5,
+    version: 1,
     text: (
       <ul className="m-8 mr-0 list-disc">
         <li className="mb-4">

--- a/js/components/operatorSignIn/text.tsx
+++ b/js/components/operatorSignIn/text.tsx
@@ -1,0 +1,29 @@
+import { ReactElement } from "react";
+
+// 🚨 You MUST change the version if you change the text!
+// 🚨 You MUST update the document at https://www.notion.so/mbta-downtown-crossing/Attestation-Text-History-7f7117d7c4574013a48c6819c7809c4a?pvs=4
+export const useSignInText = (): {
+  version: number;
+  text: ReactElement;
+} => {
+  // Check the time only once on mount so that the text doesn't change if the time changes.
+  return {
+    version: 5,
+    text: (
+      <ul className="m-8 mr-0 list-disc">
+        <li className="mb-4">
+          I do not have an electronic device in my possession.
+        </li>
+        <li className="mb-4">
+          I am fit for duty, and I do not possess nor am I under the influence
+          of alcohol, prohibited drugs, or non-authorized medication, whether
+          prescribed or non-prescribed.
+        </li>
+        <li>
+          I have a valid ROW Card and Certification Card in my possession.
+        </li>
+        <li>I have read the Day Orders.</li>
+      </ul>
+    ),
+  };
+};

--- a/js/hooks/useEmployees.ts
+++ b/js/hooks/useEmployees.ts
@@ -1,0 +1,22 @@
+import { useApiResult } from "../api";
+import { Employee, EmployeeList } from "../models/employee";
+
+const EMPLOYEES_API_PATH = "/api/employees";
+
+const parse = (list: EmployeeList) =>
+  list.map((emp: Employee) => ({
+    ...emp,
+    preferred_first: undefined,
+  }));
+
+export const useEmployees = () => {
+  return useApiResult({
+    RawData: EmployeeList,
+    url: EMPLOYEES_API_PATH,
+    parser: parse,
+  });
+};
+
+export const findEmployeeByBadge = (employees: Employee[], badge: string) => {
+  return employees.find((employee) => employee.badge === badge);
+};

--- a/js/models/employee.ts
+++ b/js/models/employee.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const Employee = z.object({
+  first_name: z.string(),
+  preferred_first: z.string().optional(),
+  last_name: z.string(),
+  badge: z.string(),
+});
+
+export type Employee = z.infer<typeof Employee>;
+
+export const EmployeeList = z.array(Employee);
+export type EmployeeList = z.infer<typeof EmployeeList>;

--- a/js/test/components/operatorSignIn/attestation.test.tsx
+++ b/js/test/components/operatorSignIn/attestation.test.tsx
@@ -1,4 +1,5 @@
 import { Attestation } from "../../../components/operatorSignIn/attestation";
+import { employeeFactory } from "../../helpers/factory";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -6,12 +7,7 @@ jest.mock("../../../hooks/useEmployees.ts", () => ({
   __esModule: true,
   findEmployeeByBadge: jest.fn((_employees, badge) => {
     if (badge === "123") {
-      return {
-        first_name: "Firsty",
-        preferred_first: "Preferredy",
-        last_name: "Lasty",
-        badge: "123",
-      };
+      return employeeFactory.build();
     }
     return undefined;
   }),

--- a/js/test/components/operatorSignIn/attestation.test.tsx
+++ b/js/test/components/operatorSignIn/attestation.test.tsx
@@ -1,0 +1,64 @@
+import { Attestation } from "../../../components/operatorSignIn/attestation";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("../../../hooks/useEmployees.ts", () => ({
+  __esModule: true,
+  findEmployeeByBadge: jest.fn((_employees, badge) => {
+    if (badge === "123") {
+      return {
+        first_name: "Firsty",
+        preferred_first: "Preferredy",
+        last_name: "Lasty",
+        badge: "123",
+      };
+    }
+    return undefined;
+  }),
+  useEmployees: jest.fn(() => ({
+    status: "ok",
+    result: [],
+  })),
+}));
+
+describe("Attestation", () => {
+  test("displays sign-in text", () => {
+    const view = render(<Attestation badge="123" onComplete={jest.fn()} />);
+    expect(
+      view.getByText("I do not have an electronic device in my possession."),
+    ).toBeInTheDocument();
+  });
+
+  test("refers to operators by preferred first name (if available)", () => {
+    const view = render(<Attestation badge="123" onComplete={jest.fn()} />);
+    expect(view.getByText("Preferredy Lasty")).toBeInTheDocument();
+  });
+
+  test("refers to operators by Operator #XXXX if name not available", () => {
+    const view = render(
+      <Attestation badge="00000000" onComplete={jest.fn()} />,
+    );
+    expect(view.getByText("Operator #00000000")).toBeInTheDocument();
+  });
+
+  test("contains signature text box", () => {
+    const view = render(<Attestation badge="123" onComplete={jest.fn()} />);
+    expect(view.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  test("contains Complete button", () => {
+    const view = render(<Attestation badge="123" onComplete={jest.fn()} />);
+    expect(
+      view.getByRole("button", { name: "Complete Fit for Duty Check" }),
+    ).toBeInTheDocument();
+  });
+
+  test("executes onComplete function on button click", async () => {
+    const onComplete = jest.fn();
+    const view = render(<Attestation badge="123" onComplete={onComplete} />);
+    await userEvent.click(
+      view.getByRole("button", { name: "Complete Fit for Duty Check" }),
+    );
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+});

--- a/js/test/components/operatorSignIn/operatorSelection.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSelection.test.tsx
@@ -1,5 +1,6 @@
 import { OperatorSelection } from "../../../components/operatorSignIn/operatorSelection";
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 describe("OperatorSelection", () => {
   test("displays NFC badge tap placeholder when NFC is supported", () => {
@@ -28,5 +29,17 @@ describe("OperatorSelection", () => {
     expect(
       view.getByRole("textbox", { name: /search for an operator/i }),
     ).toBeInTheDocument();
+  });
+
+  test("executes onOK when OK button is clicked", async () => {
+    const onOK = jest.fn();
+    const view = render(<OperatorSelection onOK={onOK} nfcSupported={true} />);
+
+    const textField = view.getByRole("textbox");
+    const button = view.getByRole("button");
+    await userEvent.type(textField, "123");
+    await userEvent.click(button);
+
+    expect(onOK).toHaveBeenCalledExactlyOnceWith("123");
   });
 });

--- a/js/test/components/operatorSignIn/operatorSelection.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSelection.test.tsx
@@ -3,13 +3,17 @@ import { render } from "@testing-library/react";
 
 describe("OperatorSelection", () => {
   test("displays NFC badge tap placeholder when NFC is supported", () => {
-    const view = render(<OperatorSelection nfcSupported={true} />);
+    const view = render(
+      <OperatorSelection onOK={jest.fn()} nfcSupported={true} />,
+    );
 
     expect(view.getByText(/waiting for badge tap/i)).toBeInTheDocument();
   });
 
   test("displays message when NFC is not supported", () => {
-    const view = render(<OperatorSelection nfcSupported={false} />);
+    const view = render(
+      <OperatorSelection onOK={jest.fn()} nfcSupported={false} />,
+    );
 
     expect(
       view.getByText(/badge tap is not supported on this device/i),
@@ -17,7 +21,9 @@ describe("OperatorSelection", () => {
   });
 
   test("has an input for operator search", () => {
-    const view = render(<OperatorSelection nfcSupported={true} />);
+    const view = render(
+      <OperatorSelection onOK={jest.fn()} nfcSupported={true} />,
+    );
 
     expect(
       view.getByRole("textbox", { name: /search for an operator/i }),

--- a/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
@@ -12,7 +12,7 @@ describe("OperatorSignInModal", () => {
   test("can close the modal", async () => {
     const view = render(<OperatorSignInModal />);
 
-    await userEvent.click(view.getByRole("button"));
+    await userEvent.click(view.getByRole("button", { name: "[x]" }));
 
     expect(view.queryByText(/fit for duty check/i)).not.toBeInTheDocument();
   });

--- a/js/test/helpers/factory.ts
+++ b/js/test/helpers/factory.ts
@@ -1,0 +1,9 @@
+import { Employee } from "../../models/employee";
+import { Factory } from "fishery";
+
+export const employeeFactory = Factory.define<Employee>(() => ({
+  first_name: "Firsty",
+  preferred_first: "Preferredy",
+  last_name: "Lasty",
+  badge: "123",
+}));

--- a/js/test/hooks/useEmployees.test.ts
+++ b/js/test/hooks/useEmployees.test.ts
@@ -1,0 +1,60 @@
+import { fetch } from "../../browser";
+import { findEmployeeByBadge, useEmployees } from "../../hooks/useEmployees";
+import { PromiseWithResolvers } from "../helpers/promiseWithResolvers";
+import { renderHook, waitFor } from "@testing-library/react";
+
+jest.mock("../../browser", () => ({
+  __esModule: true,
+  fetch: jest.fn(),
+}));
+
+const TEST_DATA = {
+  data: [
+    {
+      first_name: "Christopher",
+      preferred_first: "Chris",
+      last_name: "Robin",
+      badge: "123",
+    },
+  ],
+};
+
+const TEST_PARSED = [
+  {
+    first_name: "Christopher",
+    preferred_first: undefined,
+    last_name: "Robin",
+    badge: "123",
+  },
+];
+
+describe("useEmployees", () => {
+  test("parses api response", async () => {
+    const { promise, resolve } = PromiseWithResolvers<Response>();
+    jest.mocked(fetch).mockReturnValue(promise);
+
+    const { result } = renderHook(useEmployees);
+
+    resolve({
+      status: 200,
+      json: () =>
+        new Promise((resolve) => {
+          resolve(TEST_DATA);
+        }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ status: "ok", result: TEST_PARSED });
+    });
+  });
+});
+
+describe("findEmployeeByBadge", () => {
+  test("finds an employee in an array by badge number", () => {
+    expect(findEmployeeByBadge(TEST_PARSED, "123")).toEqual(TEST_PARSED[0]);
+  });
+
+  test("returns undefined if not found", () => {
+    expect(findEmployeeByBadge(TEST_PARSED, "1234")).toBeUndefined();
+  });
+});

--- a/js/test/hooks/useEmployees.test.ts
+++ b/js/test/hooks/useEmployees.test.ts
@@ -1,5 +1,6 @@
 import { fetch } from "../../browser";
 import { findEmployeeByBadge, useEmployees } from "../../hooks/useEmployees";
+import { employeeFactory } from "../helpers/factory";
 import { PromiseWithResolvers } from "../helpers/promiseWithResolvers";
 import { renderHook, waitFor } from "@testing-library/react";
 
@@ -9,23 +10,13 @@ jest.mock("../../browser", () => ({
 }));
 
 const TEST_DATA = {
-  data: [
-    {
-      first_name: "Christopher",
-      preferred_first: "Chris",
-      last_name: "Robin",
-      badge: "123",
-    },
-  ],
+  data: [employeeFactory.build()],
 };
 
 const TEST_PARSED = [
-  {
-    first_name: "Christopher",
+  employeeFactory.build({
     preferred_first: undefined,
-    last_name: "Robin",
-    badge: "123",
-  },
+  }),
 ];
 
 describe("useEmployees", () => {

--- a/lib/orbit_web/controllers/employees_controller.ex
+++ b/lib/orbit_web/controllers/employees_controller.ex
@@ -20,6 +20,6 @@ defmodule OrbitWeb.EmployeesController do
         end
       )
 
-    conn |> json(%{data: employees})
+    json(conn, %{data: employees})
   end
 end

--- a/lib/orbit_web/controllers/employees_controller.ex
+++ b/lib/orbit_web/controllers/employees_controller.ex
@@ -1,0 +1,25 @@
+defmodule OrbitWeb.EmployeesController do
+  alias Orbit.Employee
+  use OrbitWeb, :controller
+  import Ecto.Query
+
+  alias Orbit.Repo
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    employees =
+      Enum.map(
+        Repo.all(from(e in Employee)),
+        fn e ->
+          %{
+            first_name: e.first_name,
+            # preferred_first: e.preferred_first,
+            last_name: e.last_name,
+            badge: e.badge_number
+          }
+        end
+      )
+
+    conn |> json(%{data: employees})
+  end
+end

--- a/lib/orbit_web/router.ex
+++ b/lib/orbit_web/router.ex
@@ -52,6 +52,14 @@ defmodule OrbitWeb.Router do
   end
 
   scope "/", OrbitWeb do
+    pipe_through :browser
+    pipe_through :api
+    pipe_through :authenticated
+
+    get "/api/employees", EmployeesController, :index
+  end
+
+  scope "/", OrbitWeb do
     # no pipe
     get "/_health", HealthController, :index
     get "/_health_db", HealthDbController, :index

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-storybook": "^0.8.0",
         "eslint-plugin-testing-library": "^6.2.2",
+        "fishery": "^2.2.2",
         "globals": "^15.3.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -9841,6 +9842,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fishery": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.2.2.tgz",
+      "integrity": "sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==",
+      "dev": true,
+      "dependencies": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "dev": true,
@@ -13233,6 +13243,12 @@
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "node_modules/lodash.zip": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-storybook": "^0.8.0",
     "eslint-plugin-testing-library": "^6.2.2",
+    "fishery": "^2.2.2",
     "globals": "^15.3.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/stories/components/operatorSignIn/attestation.stories.tsx
+++ b/stories/components/operatorSignIn/attestation.stories.tsx
@@ -1,0 +1,11 @@
+import { Attestation } from "../../../js/components/operatorSignIn/attestation";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Attestation> = {
+  component: Attestation,
+};
+
+export default meta;
+type Story = StoryObj<typeof Attestation>;
+
+export const Primary: Story = {};

--- a/test/orbit_web/controllers/employees_controller_test.exs
+++ b/test/orbit_web/controllers/employees_controller_test.exs
@@ -1,0 +1,23 @@
+defmodule OrbitWeb.EmployeesControllerTest do
+  use OrbitWeb.ConnCase
+  import Orbit.Factory
+
+  describe "index" do
+    @tag :authenticated
+    test "fetches all employees", %{conn: conn} do
+      insert(:employee)
+      conn = get(conn, ~p"/api/employees")
+
+      assert %{
+               "data" => [
+                 %{
+                   "badge" => _badge,
+                   "first_name" => "Fake",
+                   "last_name" => "Person"
+                   #  "preferred_first" => nil
+                 }
+               ]
+             } = json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
Asana Task: [Show operator sign in modal with operator info](https://app.asana.com/0/1206105669438487/1207373383816236/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Add operator sign-in attestation with http fetch to `/api/employees` for name.

⚠️ @lemald This has some boilerplate/todo/comments for preferred first name, even though we haven't integrated it yet.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
