### PR TITLE
fix: have eslint react plugin detect react version

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,10 @@ export default tseslint.config(
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
   // jsx-runtime only disables rules, so need both recommended and jsx.
-  pluginReactRecommended,
+  {
+    ...pluginReactRecommended,
+    settings: { react: { version: "detect" } },
+  },
   pluginReactJsx,
   configPrettier,
   {


### PR DESCRIPTION
Asana Task: none

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

I noticed that we had been getting the following warning when running ESLint:

```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```

It's a bit weird because we're on the new configuration format and most of the README for the React ESLint plugin still references the old configuration format, but I finally found the right configuration change to specify `detect` as the version and have the plugin auto-detect while not give us a warning.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(X)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
