### PR TITLE
fix: nfc signins get 'nfc' method

### DIFF
--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -54,9 +54,14 @@ export const OperatorSelection = ({
       <button
         disabled={!buttonEnabled}
         onClick={() => {
-          // badgeEntry cannot be null; otherwise the button would be disabled!
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          onOK(badgeEntry!);
+          // This should never happen, but throw just in case.
+          if (badgeEntry === null) {
+            throw new Error(
+              "operatorSelection badgeEntry was impossibly null.",
+            );
+          }
+
+          onOK(badgeEntry);
         }}
         className={className([
           "rounded bg-mbta-blue text-gray-200 mt-3 w-1/4 max-w-32 mx-auto",

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -3,6 +3,7 @@ import { findEmployeeByBadgeSerial } from "../../hooks/useEmployees";
 import { useNfc } from "../../hooks/useNfc";
 import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
+import { BadgeEntry } from "./types";
 import { ReactElement, useEffect, useId, useState } from "react";
 
 export const OperatorSelection = ({
@@ -11,11 +12,11 @@ export const OperatorSelection = ({
   employees,
 }: {
   nfcSupported: boolean;
-  onOK: (badge: string) => void;
+  onOK: (badgeEntry: BadgeEntry) => void;
   employees: ApiResult<Employee[]>;
 }): ReactElement => {
   const inputId = useId();
-  const [badgeEntry, setBadgeEntry] = useState<string>("");
+  const [badgeEntry, setBadgeEntry] = useState<BadgeEntry | null>(null);
 
   const { result: nfcResult } = useNfc();
 
@@ -27,14 +28,14 @@ export const OperatorSelection = ({
       )?.badge;
 
       if (badge) {
-        onOK(badge);
+        onOK({ number: badge, method: "nfc" });
       } else {
         // handle case where we can't find operator for badge
       }
     }
   }, [nfcResult, employees, onOK]);
 
-  const buttonEnabled = badgeEntry !== "";
+  const buttonEnabled = badgeEntry !== null;
 
   return (
     <div className="flex flex-col content-stretch">
@@ -47,13 +48,15 @@ export const OperatorSelection = ({
         id={inputId}
         inputMode="numeric"
         onChange={(evt) => {
-          setBadgeEntry(evt.target.value);
+          setBadgeEntry({ number: evt.target.value, method: "manual" });
         }}
       />
       <button
         disabled={!buttonEnabled}
         onClick={() => {
-          onOK(badgeEntry);
+          // badgeEntry cannot be null; otherwise the button would be disabled!
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          onOK(badgeEntry!);
         }}
         className={className([
           "rounded bg-mbta-blue text-gray-200 mt-3 w-1/4 max-w-32 mx-auto",

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -5,6 +5,7 @@ import { Modal } from "../modal";
 import { Attestation } from "./attestation";
 import { Error, Success } from "./complete";
 import { OperatorSelection } from "./operatorSelection";
+import { BadgeEntry } from "./types";
 import { DateTime } from "luxon";
 import { ReactElement, useEffect, useState } from "react";
 
@@ -14,17 +15,17 @@ enum CompleteState {
 }
 
 const submit = (
-  badge: string,
+  badgeEntry: BadgeEntry,
   setComplete: React.Dispatch<React.SetStateAction<CompleteState | null>>,
   setLoading: React.Dispatch<React.SetStateAction<boolean>>,
 ) => {
   setLoading(true);
 
   post("/api/signin", {
-    signed_in_employee_badge: badge,
+    signed_in_employee_badge: badgeEntry.number,
     signed_in_at: DateTime.now().toUnixInteger(),
     line: "blue",
-    method: "manual",
+    method: badgeEntry.method,
   })
     .then((response) => {
       if (!response.ok) {
@@ -45,7 +46,7 @@ const submit = (
 
 export const OperatorSignInModal = (): ReactElement => {
   const [show, setShow] = useState<boolean>(true);
-  const [badge, setBadge] = useState<string | null>(null);
+  const [badge, setBadge] = useState<BadgeEntry | null>(null);
   const [complete, setComplete] = useState<CompleteState | null>(null);
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -67,8 +68,8 @@ export const OperatorSignInModal = (): ReactElement => {
   const employee =
     employees.status === "ok" &&
     badge !== null &&
-    findEmployeeByBadge(employees.result, badge);
-  const name = employee ? employee.first_name : `Operator ${badge}`;
+    findEmployeeByBadge(employees.result, badge.number);
+  const name = employee ? employee.first_name : `Operator ${badge?.number}`;
 
   return (
     <Modal
@@ -95,7 +96,7 @@ export const OperatorSignInModal = (): ReactElement => {
           employees={employees}
         />
       : <Attestation
-          badge={badge}
+          badge={badge.number}
           loading={loading}
           onComplete={() => {
             submit(badge, setComplete, setLoading);

--- a/js/components/operatorSignIn/types.ts
+++ b/js/components/operatorSignIn/types.ts
@@ -1,0 +1,6 @@
+export type BadgeMethod = "manual" | "nfc";
+
+export type BadgeEntry = {
+  number: string;
+  method: BadgeMethod;
+};

--- a/js/test/components/operatorSignIn/operatorSelection.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSelection.test.tsx
@@ -75,7 +75,10 @@ describe("OperatorSelection", () => {
     await userEvent.type(textField, "123");
     await userEvent.click(button);
 
-    expect(onOK).toHaveBeenCalledExactlyOnceWith("123");
+    expect(onOK).toHaveBeenCalledExactlyOnceWith({
+      number: "123",
+      method: "manual",
+    });
   });
 
   test("executes onOK on successful badge tap", () => {
@@ -102,6 +105,9 @@ describe("OperatorSelection", () => {
       />,
     );
 
-    expect(onOK).toHaveBeenCalledExactlyOnceWith("123");
+    expect(onOK).toHaveBeenCalledExactlyOnceWith({
+      number: "123",
+      method: "nfc",
+    });
   });
 });


### PR DESCRIPTION
Asana Task: Follow up on [Fit for Duty Check modal interaction](https://app.asana.com/0/1206105669438487/1207259534606018/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Title says it all. Merging two earlier PRs meant sign-ins were hardcoded to method "manual"- nfc signins should get "nfc".

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
