### PR TITLE
fix: operators without rfid serials weren't included in API results

### DIFF
--- a/lib/orbit_web/controllers/employees_controller.ex
+++ b/lib/orbit_web/controllers/employees_controller.ex
@@ -11,8 +11,7 @@ defmodule OrbitWeb.EmployeesController do
       Enum.map(
         Repo.all(
           from e in Employee,
-            join: b in assoc(e, :badge_serials),
-            where: e.id == b.employee_id,
+            left_join: b in assoc(e, :badge_serials),
             preload: [badge_serials: b]
         ),
         fn e ->

--- a/test/orbit_web/controllers/employees_controller_test.exs
+++ b/test/orbit_web/controllers/employees_controller_test.exs
@@ -20,5 +20,23 @@ defmodule OrbitWeb.EmployeesControllerTest do
                ]
              } = json_response(conn, 200)
     end
+
+    @tag :authenticated
+    test "fetches employees without badge serial data", %{conn: conn} do
+      insert(:employee, %{badge_serials: []})
+      conn = get(conn, ~p"/api/employees")
+
+      assert %{
+               "data" => [
+                 %{
+                   "badge" => _badge,
+                   "first_name" => "Fake",
+                   "last_name" => "Person",
+                   "preferred_first" => "Preferredy",
+                   "badge_serials" => []
+                 }
+               ]
+             } = json_response(conn, 200)
+    end
   end
 end


### PR DESCRIPTION
Asana Task: [🐞 orbit: some operators not being returned in API results](https://app.asana.com/0/1200273269966439/1207834935765422/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

I'm not sure if this fixes all of the exact issues, but it's definitely a case that would cause this problem.

I took inspiration from the second example under [here](https://hexdocs.pm/ecto/Ecto.Query.html#join/5-keywords-examples), the one querying on `Post` and joining to `comments`, since that was a similar case to our own.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
