### PR TITLE
fix: preferred name empty string to nil

### DIFF
--- a/lib/orbit/import/personnel.ex
+++ b/lib/orbit/import/personnel.ex
@@ -35,7 +35,7 @@ defmodule Orbit.Import.Personnel do
       |> Enum.map(
         &%Employee{
           first_name: &1["FIRST_NAME"],
-          preferred_first: &1["PREF_FIRST_NM_SRCH"],
+          preferred_first: empty_to_nil(&1["PREF_FIRST_NM_SRCH"]),
           middle_initial: String.at(&1["MIDDLE_NAME"], 0),
           last_name: &1["LAST_NAME"],
           email: empty_to_nil(&1["WORK_EMAIL_ADDRESS"]),

--- a/test/orbit/import/personnel_test.exs
+++ b/test/orbit/import/personnel_test.exs
@@ -77,5 +77,27 @@ defmodule Orbit.Import.PersonnelTest do
                email: nil
              } = Repo.one(from(e in Employee, where: e.first_name == "Nemo"))
     end
+
+    test "properly formats empty preferred name" do
+      Personnel.import_rows(
+        [
+          %{
+            "FIRST_NAME" => "Nemo",
+            "PREF_FIRST_NM_SRCH" => "",
+            "MIDDLE_NAME" => "A",
+            "WORK_EMAIL_ADDRESS" => "",
+            "LAST_NAME" => "Smith",
+            "EMPLOYEE_ID" => "0123456",
+            "CUSTOM_FIELD3" => "Area",
+            "CUSTOM_VALUE3" => "114"
+          }
+        ],
+        MapSet.new(["114"])
+      )
+
+      assert %Employee{
+               preferred_first: nil
+             } = Repo.one(from(e in Employee, where: e.first_name == "Nemo"))
+    end
   end
 end


### PR DESCRIPTION
Asana Task: [🐞 orbit should treat preferred="" as nil](https://app.asana.com/0/1206105669438487/1207881358362318/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

This is causing empty preferred names to go in as `""`, which are coming into the UI.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed (**it's a minor regression**)

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
