### PR TITLE
fix: preferred_first optional() to nullable()

### DIFF
--- a/js/models/employee.ts
+++ b/js/models/employee.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const Employee = z.object({
   first_name: z.string(),
-  preferred_first: z.string().optional(),
+  preferred_first: z.string().nullable(),
   last_name: z.string(),
   badge: z.string(),
   badge_serials: z.array(z.string()),

--- a/js/test/hooks/useEmployees.test.ts
+++ b/js/test/hooks/useEmployees.test.ts
@@ -14,10 +14,15 @@ jest.mock("../../browser", () => ({
 }));
 
 const TEST_DATA = {
-  data: [employeeFactory.build()],
+  data: [
+    employeeFactory.build(),
+    employeeFactory.build({
+      preferred_first: null,
+    }),
+  ],
 };
 
-const TEST_PARSED = [TEST_DATA.data[0]];
+const TEST_PARSED = TEST_DATA.data;
 
 describe("useEmployees", () => {
   test("parses api response", async () => {


### PR DESCRIPTION
Asana Task: [🐞 orbit should treat preferred="" as nil](https://app.asana.com/0/1206105669438487/1207881358362318/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

oops!

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
