### PR TITLE
fix: change /list's back button to avoid using history.go

### DIFF
--- a/js/browser.ts
+++ b/js/browser.ts
@@ -3,7 +3,3 @@ export const fetch = window.fetch;
 export const reload = () => {
   window.location.reload();
 };
-
-export const back = () => {
-  history.go(-1);
-};

--- a/js/components/operatorSignIn/list.tsx
+++ b/js/components/operatorSignIn/list.tsx
@@ -1,9 +1,9 @@
-import { back } from "../../browser";
 import { lookupDisplayName, useEmployees } from "../../hooks/useEmployees";
 import { useSignins } from "../../hooks/useSignIns";
 import { HeavyRailLine } from "../../types";
 import { DateTime } from "luxon";
 import { ReactElement } from "react";
+import { Link } from "react-router-dom";
 
 export const List = ({ line }: { line: HeavyRailLine }): ReactElement => {
   const employees = useEmployees();
@@ -19,14 +19,12 @@ export const List = ({ line }: { line: HeavyRailLine }): ReactElement => {
 
   return (
     <div className="m-2">
-      <button
-        className="bg-mbta-blue text-gray-100 rounded-md p-2 text-sm m-5"
-        onClick={() => {
-          back();
-        }}
+      <Link
+        className="inline-block bg-mbta-blue text-gray-100 rounded-md p-2 text-sm m-3"
+        to={"/"}
       >
         Back
-      </button>
+      </Link>
       <u>Today&apos;s sign-ins</u>
       <table>
         <thead>

--- a/js/test/components/operatorSignIn/list.test.tsx
+++ b/js/test/components/operatorSignIn/list.test.tsx
@@ -3,6 +3,7 @@ import { displayName } from "../../../models/employee";
 import { employeeFactory } from "../../helpers/factory";
 import { render } from "@testing-library/react";
 import { DateTime } from "luxon";
+import { MemoryRouter } from "react-router-dom";
 
 const EMPLOYEES = [employeeFactory.build()];
 jest.mock("../../../hooks/useEmployees", () => ({
@@ -33,7 +34,11 @@ jest.mock("../../../hooks/useSignIns", () => ({
 
 describe("List", () => {
   test("shows a sign-in", () => {
-    const view = render(<List line="blue" />);
+    const view = render(
+      <MemoryRouter>
+        <List line="blue" />
+      </MemoryRouter>,
+    );
     expect(view.getByText("12:45 PM")).toBeInTheDocument();
     expect(
       view.getByText(


### PR DESCRIPTION
Asana Task: None

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

I regret using browser navigation for the back button, because it doesn't work with a direct link to `/list`.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
