### PR TITLE
Admin permission

### DIFF
--- a/lib/orbit/authentication/user.ex
+++ b/lib/orbit/authentication/user.ex
@@ -6,6 +6,7 @@ defmodule Orbit.Authentication.User do
   @type t :: %__MODULE__{
           id: integer(),
           email: String.t(),
+          admin?: boolean(),
           permissions: [UserPermission.t()],
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -14,6 +15,7 @@ defmodule Orbit.Authentication.User do
   schema "users" do
     field(:email, :string)
     field(:permissions, {:array, UserPermission})
+    field(:admin?, :boolean, virtual: true)
     timestamps()
   end
 

--- a/lib/orbit_web/auth/guardian.ex
+++ b/lib/orbit_web/auth/guardian.ex
@@ -1,18 +1,21 @@
 defmodule OrbitWeb.Auth.Guardian do
   use Guardian, otp_app: :orbit
+  alias Orbit.Authentication.User
+  alias Orbit.Repo
 
   @spec subject_for_token(Guardian.Token.resource(), Guardian.Token.claims()) ::
           {:ok, String.t()} | {:error, atom()}
-  def subject_for_token(resource, _claims) do
-    sub = resource
-    {:ok, sub}
+  def subject_for_token(%User{email: email}, _claims) do
+    {:ok, email}
   end
 
   @spec resource_from_claims(Guardian.Token.claims()) ::
           {:ok, Guardian.Token.resource()} | {:error, atom()}
   def resource_from_claims(%{"sub" => id}) do
-    resource = id
-    {:ok, resource}
+    case Repo.get_by(User, email: id) do
+      nil -> {:error, :user_not_found}
+      user -> {:ok, user}
+    end
   end
 end
 

--- a/lib/orbit_web/auth/guardian.ex
+++ b/lib/orbit_web/auth/guardian.ex
@@ -3,6 +3,8 @@ defmodule OrbitWeb.Auth.Guardian do
   alias Orbit.Authentication.User
   alias Orbit.Repo
 
+  @admin_group "orbit-admin"
+
   @spec subject_for_token(Guardian.Token.resource(), Guardian.Token.claims()) ::
           {:ok, String.t()} | {:error, atom()}
   def subject_for_token(%User{email: email}, _claims) do
@@ -11,10 +13,10 @@ defmodule OrbitWeb.Auth.Guardian do
 
   @spec resource_from_claims(Guardian.Token.claims()) ::
           {:ok, Guardian.Token.resource()} | {:error, atom()}
-  def resource_from_claims(%{"sub" => id}) do
+  def resource_from_claims(%{"sub" => id, "groups" => groups}) do
     case Repo.get_by(User, email: id) do
       nil -> {:error, :user_not_found}
-      user -> {:ok, user}
+      user -> {:ok, %User{user | admin?: @admin_group in groups}}
     end
   end
 end

--- a/lib/orbit_web/controllers/auth_controller.ex
+++ b/lib/orbit_web/controllers/auth_controller.ex
@@ -41,7 +41,6 @@ defmodule OrbitWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_auth: %{provider: :keycloak} = auth}} = conn, _params) do
-    username = String.replace(auth.info.email, "MBTA.com", "mbta.com")
     # credentials = auth.credentials
 
     # Ignore auth provider's TTL, set ours to 30 days so users don't have to log back in
@@ -58,7 +57,7 @@ defmodule OrbitWeb.AuthController do
 
     conn
     |> Auth.login(
-      username,
+      auth.info.email,
       ttl_seconds,
       groups,
       logout_url

--- a/test/orbit_web/auth/guardian_test.exs
+++ b/test/orbit_web/auth/guardian_test.exs
@@ -1,6 +1,7 @@
 defmodule OrbitWeb.Auth.GuardianTest do
   use Orbit.DataCase
   alias OrbitWeb.Auth.Guardian
+  alias Orbit.Authentication.User
   import Orbit.Factory
 
   describe "subject_for_token/2" do
@@ -15,7 +16,15 @@ defmodule OrbitWeb.Auth.GuardianTest do
     test "pulls user from database" do
       user = insert(:user)
 
-      assert {:ok, user} == Guardian.resource_from_claims(%{"sub" => user.email})
+      assert {:ok, %User{user | admin?: false}} ==
+               Guardian.resource_from_claims(%{"sub" => user.email, "groups" => []})
+    end
+
+    test "sets the admin flag if user is in appropriate group" do
+      user = insert(:user)
+
+      assert {:ok, %User{user | admin?: true}} ==
+               Guardian.resource_from_claims(%{"sub" => user.email, "groups" => ["orbit-admin"]})
     end
   end
 end

--- a/test/orbit_web/auth/guardian_test.exs
+++ b/test/orbit_web/auth/guardian_test.exs
@@ -1,0 +1,21 @@
+defmodule OrbitWeb.Auth.GuardianTest do
+  use Orbit.DataCase
+  alias OrbitWeb.Auth.Guardian
+  import Orbit.Factory
+
+  describe "subject_for_token/2" do
+    test "returns email address field" do
+      user = build(:user)
+
+      assert {:ok, user.email} == Guardian.subject_for_token(user, %{})
+    end
+  end
+
+  describe "resource_for_claims/1" do
+    test "pulls user from database" do
+      user = insert(:user)
+
+      assert {:ok, user} == Guardian.resource_from_claims(%{"sub" => user.email})
+    end
+  end
+end

--- a/test/orbit_web/auth/guardian_test.exs
+++ b/test/orbit_web/auth/guardian_test.exs
@@ -1,7 +1,7 @@
 defmodule OrbitWeb.Auth.GuardianTest do
   use Orbit.DataCase
-  alias OrbitWeb.Auth.Guardian
   alias Orbit.Authentication.User
+  alias OrbitWeb.Auth.Guardian
   import Orbit.Factory
 
   describe "subject_for_token/2" do

--- a/test/orbit_web/controllers/auth_controller_test.exs
+++ b/test/orbit_web/controllers/auth_controller_test.exs
@@ -2,9 +2,9 @@ defmodule OrbitWeb.AuthControllerTest do
   use OrbitWeb.ConnCase
   alias OrbitWeb.Auth.Auth
 
-  defp login_with_groups(conn, _groups) do
+  defp login_with_groups(conn, groups) do
     conn
-    |> get(~p"/auth/keycloak/callback?#{%{"email" => "user@example.com"}}")
+    |> get(~p"/auth/keycloak/callback?#{%{"email" => "user@example.com", "groups" => groups}}")
   end
 
   describe "/login" do
@@ -18,6 +18,13 @@ defmodule OrbitWeb.AuthControllerTest do
     test "valid credentials redirect to /", %{conn: conn} do
       conn = login_with_groups(conn, [])
       assert redirected_to(conn) == "/"
+    end
+
+    test "group information is saved in the claims", %{conn: conn} do
+      conn = login_with_groups(conn, ["some-group"])
+      assert redirected_to(conn) == "/"
+
+      assert %{"groups" => ["some-group"]} = Guardian.Plug.current_claims(conn)
     end
 
     test "remembers target URL", %{conn: conn} do


### PR DESCRIPTION
Asana Task: [Set up user access / permissions](https://app.asana.com/0/1200273269966439/1207259534605993/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

This shuffles things around so that the "resource" in Guardian terms is an actual `%User{...}` struct, and adds a non-persisted field that gets set based on the presence or absence of the appropriate group.

Also note that this will trigger an internal server error for users already logged in who don't have a `"groups"` key in their token. Since we don't have real active users yet I don't think it's very important to make it backwards compatible, and you can just clear your cookies for the appropriate domains.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
