### PR TITLE
test: mute logs for passing tests

### DIFF
--- a/test/orbit_web/controllers/auth_controller_test.exs
+++ b/test/orbit_web/controllers/auth_controller_test.exs
@@ -36,7 +36,6 @@ defmodule OrbitWeb.AuthControllerTest do
       assert redirected_to(conn) == "/help"
     end
 
-    @tag capture_log: true
     test "invalid credentials redirect to /login", %{conn: conn} do
       conn = get(conn, ~p"/auth/keycloak/callback?#{%{"invalid" => "true"}}")
       assert redirected_to(conn) == "/login"

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
-ExUnit.start()
+# capture_log hides all logs for passing tests (but not failing tests)
+ExUnit.start(capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(Orbit.Repo, :manual)


### PR DESCRIPTION
Asana Task: [🛠 Mute noisy logging during orbit tests](https://app.asana.com/0/1200882337457260/1208126001173865/f), which came out of [📐 Orbit: allow manually associating a badge serial with an operator for testing](https://app.asana.com/0/1200689710863995/1207890347662644/f)

This approach, which was suggested in https://github.com/navinpeiris/logster/issues/29#issuecomment-2306116754 , is even better than what I was expecting. It mutes all logs in passing tests, and collects any logs for failing tests together. Example:

<img width="640" alt="Test failure. Assert false. The following output was logged." src="https://github.com/user-attachments/assets/e03d2b34-cf0d-489f-b9e7-3849adf53089">

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Description goes here.
Include screenshots if relevant.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
