### PR TITLE
Sign-in record export

### DIFF
--- a/js/components/home.tsx
+++ b/js/components/home.tsx
@@ -26,30 +26,31 @@ export const Home = (): ReactElement => {
         </button>
       </section>
       <section className="w-full bg-gray-100/50 py-5">
-        <div className="mx-auto max-w-lg px-2">
-          <p className="font-semibold">Export sign in records</p>
-        </div>
-        <div className="mt-5 flex justify-between gap-4 items-end mb-3 max-w-lg mx-auto px-2">
-          <label className="flex flex-grow flex-col">
-            <span className="text-sm">Service Date</span>
-            <input
-              type="date"
-              value={selectedDate}
-              onChange={(evt) => {
-                setSelectedDate(evt.target.value);
-              }}
-              className="rounded h-10 bg-gray-100"
-            />
-          </label>
-          <button
-            className="rounded border border-gray-300 hover:bg-gray-100 p-2 h-10"
-            onClick={() => {
-              console.log("TODO");
-            }}
-          >
-            Export Records
-          </button>
-        </div>
+        <form action="/sign-in-export" method="get" target="_blank">
+          <div className="mx-auto max-w-lg px-2">
+            <p className="font-semibold">Export sign in records</p>
+          </div>
+          <div className="mt-5 flex justify-between gap-4 items-end mb-3 max-w-lg mx-auto px-2">
+            <label className="flex flex-grow flex-col">
+              <span className="text-sm">Service Date</span>
+              <input
+                type="date"
+                name="date"
+                value={selectedDate}
+                onChange={(evt) => {
+                  setSelectedDate(evt.target.value);
+                }}
+                className="rounded h-10 bg-gray-100"
+              />
+            </label>
+            <button
+              className="rounded border border-gray-300 hover:bg-gray-100 p-2 h-10"
+              type="submit"
+            >
+              Export Records
+            </button>
+          </div>
+        </form>
       </section>
       <section className="max-w-lg mx-auto px-2 py-5">
         <p className="font-semibold mb-3">Today&apos;s sign ins</p>

--- a/lib/orbit/employee.ex
+++ b/lib/orbit/employee.ex
@@ -49,6 +49,11 @@ defmodule Orbit.Employee do
     |> cast_assoc(:badge_serials)
   end
 
+  @spec display_name(t()) :: String.t()
+  def display_name(employee) do
+    "#{employee.preferred_first || employee.first_name} #{employee.last_name}"
+  end
+
   @spec get_by_badge_serial(String.t()) :: t() | nil
   def get_by_badge_serial(serial) do
     Repo.one(

--- a/lib/orbit/import/personnel.ex
+++ b/lib/orbit/import/personnel.ex
@@ -38,7 +38,7 @@ defmodule Orbit.Import.Personnel do
           preferred_first: empty_to_nil(&1["PREF_FIRST_NM_SRCH"]),
           middle_initial: String.at(&1["MIDDLE_NAME"], 0),
           last_name: &1["LAST_NAME"],
-          email: empty_to_nil(&1["WORK_EMAIL_ADDRESS"]),
+          email: &1["WORK_EMAIL_ADDRESS"] |> String.downcase() |> empty_to_nil(),
           badge_number: String.trim_leading(&1["EMPLOYEE_ID"], "0"),
           area: String.to_integer(&1[@area_value_field])
         }

--- a/lib/orbit_web/controllers/sign_in_export_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_export_controller.ex
@@ -38,11 +38,18 @@ defmodule OrbitWeb.SignInExportController do
       )
       |> Enum.map(
         &%{
-          time: &1.signed_in_at |> DateTime.shift_zone!(@timezone) |> DateTime.to_iso8601(),
+          time:
+            &1.signed_in_at
+            |> DateTime.shift_zone!(@timezone)
+            |> Timex.format!("{YYYY}-{0M}-{0D} {0h24}:{0m}:{0s}"),
           location: "Orient Heights",
           signer_badge: &1.signed_in_employee.badge_number,
           signer_name: Employee.display_name(&1.signed_in_employee),
-          method: &1.sign_in_method,
+          method:
+            case &1.sign_in_method do
+              :nfc -> "tap"
+              :manual -> "type"
+            end,
           text_version: 1
         }
       )

--- a/lib/orbit_web/controllers/sign_in_export_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_export_controller.ex
@@ -1,0 +1,12 @@
+defmodule OrbitWeb.SignInExportController do
+  use OrbitWeb, :controller
+
+  @spec get(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def get(conn, %{"date" => _date_string}) do
+    csv = ""
+
+    conn
+    |> put_resp_content_type("application/csv")
+    |> send_resp(200, csv)
+  end
+end

--- a/lib/orbit_web/controllers/sign_in_export_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_export_controller.ex
@@ -31,6 +31,7 @@ defmodule OrbitWeb.SignInExportController do
       Repo.all(
         from osi in OperatorSignIn,
           where: ^start_datetime < osi.signed_in_at and osi.signed_in_at < ^end_datetime,
+          order_by: osi.signed_in_at,
           join: e in assoc(osi, :signed_in_employee),
           join: u in assoc(osi, :signed_in_by_user),
           preload: [signed_in_employee: e, signed_in_by_user: u]

--- a/lib/orbit_web/controllers/sign_in_export_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_export_controller.ex
@@ -38,7 +38,7 @@ defmodule OrbitWeb.SignInExportController do
     Repo.all(
       from operator_sign_in in OperatorSignIn,
         where:
-          ^start_datetime < operator_sign_in.signed_in_at and
+          ^start_datetime <= operator_sign_in.signed_in_at and
             operator_sign_in.signed_in_at < ^end_datetime,
         order_by: operator_sign_in.signed_in_at,
         join: e in assoc(operator_sign_in, :signed_in_employee),

--- a/lib/orbit_web/controllers/sign_in_export_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_export_controller.ex
@@ -21,7 +21,7 @@ defmodule OrbitWeb.SignInExportController do
            Regex.named_captures(~r"sign-ins-(?<date_string>.+)\.csv", filename),
          {:ok, date} <- Date.from_iso8601(date_string) do
       conn
-      |> put_resp_content_type("application/csv")
+      |> put_resp_content_type("text/csv")
       |> send_resp(200, fetch_sign_ins_csv(date))
     else
       _ ->

--- a/lib/orbit_web/controllers/sign_in_export_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_export_controller.ex
@@ -1,12 +1,63 @@
 defmodule OrbitWeb.SignInExportController do
   use OrbitWeb, :controller
+  alias Orbit.Employee
+  alias Orbit.OperatorSignIn
+  alias Orbit.Repo
+
+  import Ecto.Query
+
+  @timezone Application.compile_env!(:orbit, :timezone)
 
   @spec get(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def get(conn, %{"date" => _date_string}) do
-    csv = ""
+  def get(conn, %{"date" => date_string}) do
+    case Date.from_iso8601(date_string) do
+      {:ok, date} ->
+        conn
+        |> put_resp_content_type("application/csv")
+        |> send_resp(200, fetch_sign_ins_csv(date))
 
-    conn
-    |> put_resp_content_type("application/csv")
-    |> send_resp(200, csv)
+      {:error, _} ->
+        conn
+        |> put_status(:bad_request)
+        |> text("Bad Request")
+    end
+  end
+
+  @spec fetch_sign_ins_csv(Date.t()) :: String.t()
+  defp fetch_sign_ins_csv(service_date) do
+    {start_datetime, end_datetime} = Util.Time.service_date_boundaries(service_date)
+
+    rows =
+      Repo.all(
+        from osi in OperatorSignIn,
+          where: ^start_datetime < osi.signed_in_at and osi.signed_in_at < ^end_datetime,
+          join: e in assoc(osi, :signed_in_employee),
+          join: u in assoc(osi, :signed_in_by_user),
+          preload: [signed_in_employee: e, signed_in_by_user: u]
+      )
+      |> Enum.map(
+        &%{
+          time: &1.signed_in_at |> DateTime.shift_zone!(@timezone) |> DateTime.to_iso8601(),
+          location: "Orient Heights",
+          signer_badge: &1.signed_in_employee.badge_number,
+          signer_name: Employee.display_name(&1.signed_in_employee),
+          method: &1.sign_in_method,
+          text_version: 1
+        }
+      )
+
+    rows
+    |> CSV.encode(
+      headers: [
+        time: "Time",
+        location: "Location",
+        signer_badge: "Signer Badge #",
+        signer_name: "Signer Name",
+        method: "Method",
+        text_version: "Text Version"
+      ],
+      delimiter: "\n"
+    )
+    |> Enum.join()
   end
 end

--- a/lib/orbit_web/router.ex
+++ b/lib/orbit_web/router.ex
@@ -53,6 +53,8 @@ defmodule OrbitWeb.Router do
     get "/list", ReactAppController, :home
     get "/help", ReactAppController, :home
     get "/logout", AuthController, :logout
+
+    get "/sign-in-export", SignInExportController, :get
   end
 
   scope "/", OrbitWeb do

--- a/lib/orbit_web/router.ex
+++ b/lib/orbit_web/router.ex
@@ -54,7 +54,8 @@ defmodule OrbitWeb.Router do
     get "/help", ReactAppController, :home
     get "/logout", AuthController, :logout
 
-    get "/sign-in-export", SignInExportController, :get
+    get "/sign-in-export/:filename", SignInExportController, :get
+    get "/sign-in-export", SignInExportController, :get_redirect
   end
 
   scope "/", OrbitWeb do

--- a/priv/repo/migrations/20240829201608_add_employees_email_index.exs
+++ b/priv/repo/migrations/20240829201608_add_employees_email_index.exs
@@ -1,0 +1,18 @@
+defmodule Orbit.Repo.Migrations.AddEmployeesEmailIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:employees, [:email])
+
+    # couple of minor stragglers from the contact -> employees rename
+    execute(
+      "ALTER INDEX contacts_pkey RENAME TO employees_pkey",
+      "ALTER INDEX employees_pkey RENAME TO contacts_pkey"
+    )
+
+    execute(
+      "ALTER INDEX contacts_badge_number_index RENAME TO employees_badge_number_index",
+      "ALTER INDEX employees_badge_number_index RENAME TO contacts_badge_number_index"
+    )
+  end
+end

--- a/test/orbit/employee_test.exs
+++ b/test/orbit/employee_test.exs
@@ -49,6 +49,20 @@ defmodule Orbit.EmployeeTest do
                  end
   end
 
+  describe "display_name/1" do
+    test "uses preferred name if available" do
+      employee = build(:employee, %{preferred_first: "Preferred", last_name: "Name"})
+
+      assert Employee.display_name(employee) == "Preferred Name"
+    end
+
+    test "uses first name if no preferred name is specified" do
+      employee = build(:employee, %{preferred_first: nil, first_name: "First", last_name: "Name"})
+
+      assert Employee.display_name(employee) == "First Name"
+    end
+  end
+
   describe "get_by_badge_serial/1" do
     test "fetches employee by badge serial" do
       badge_serial = build(:badge_serial)

--- a/test/orbit/import/personnel_test.exs
+++ b/test/orbit/import/personnel_test.exs
@@ -37,7 +37,7 @@ defmodule Orbit.Import.PersonnelTest do
                preferred_first: "Neems",
                middle_initial: "A",
                last_name: "Smith",
-               email: "NEMO@MBTA.COM",
+               email: "nemo@mbta.com",
                area: 114
              } = Repo.one(from(e in Employee, where: e.first_name == "Nemo"))
     end

--- a/test/orbit_web/controllers/sign_in_export_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_export_controller_test.exs
@@ -35,19 +35,19 @@ defmodule OrbitWeb.SignInExportControllerTest do
       assert [
                %{
                  "Location" => "Orient Heights",
-                 "Method" => "manual",
+                 "Method" => "type",
                  "Signer Badge #" => "employee_badge0",
                  "Signer Name" => "Preferredy Person",
                  "Text Version" => "1",
-                 "Time" => "2024-08-28T17:00:00-04:00"
+                 "Time" => "2024-08-28 17:00:00"
                },
                %{
                  "Location" => "Orient Heights",
-                 "Method" => "nfc",
+                 "Method" => "tap",
                  "Signer Badge #" => "employee_badge1",
                  "Signer Name" => "Preferredy Person",
                  "Text Version" => "1",
-                 "Time" => "2024-08-28T17:10:00-04:00"
+                 "Time" => "2024-08-28 17:10:00"
                }
              ] = result
     end

--- a/test/orbit_web/controllers/sign_in_export_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_export_controller_test.exs
@@ -12,13 +12,15 @@ defmodule OrbitWeb.SignInExportControllerTest do
 
     @tag :authenticated
     test "returns CSV export", %{conn: conn} do
-      {:ok, signed_in_at, _offset} = DateTime.from_iso8601("2024-08-28T17:00:00-04:00")
+      {:ok, signed_in_at1, _offset} = DateTime.from_iso8601("2024-08-28T17:00:00-04:00")
+      {:ok, signed_in_at2, _offset} = DateTime.from_iso8601("2024-08-28T17:10:00-04:00")
 
-      insert(:operator_sign_in, %{signed_in_at: signed_in_at})
+      insert(:operator_sign_in, %{signed_in_at: signed_in_at1, sign_in_method: :manual})
+      insert(:operator_sign_in, %{signed_in_at: signed_in_at2, sign_in_method: :nfc})
 
       conn =
         get(conn, ~p"/sign-in-export", %{
-          "date" => signed_in_at |> DateTime.to_date() |> Date.to_string()
+          "date" => signed_in_at1 |> DateTime.to_date() |> Date.to_string()
         })
 
       csv = response(conn, :ok)
@@ -38,6 +40,14 @@ defmodule OrbitWeb.SignInExportControllerTest do
                  "Signer Name" => "Preferredy Person",
                  "Text Version" => "1",
                  "Time" => "2024-08-28T17:00:00-04:00"
+               },
+               %{
+                 "Location" => "Orient Heights",
+                 "Method" => "nfc",
+                 "Signer Badge #" => "employee_badge1",
+                 "Signer Name" => "Preferredy Person",
+                 "Text Version" => "1",
+                 "Time" => "2024-08-28T17:10:00-04:00"
                }
              ] = result
     end

--- a/test/orbit_web/controllers/sign_in_export_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_export_controller_test.exs
@@ -1,11 +1,52 @@
 defmodule OrbitWeb.SignInExportControllerTest do
   use OrbitWeb.ConnCase
 
+  import Orbit.Factory
+
   describe "get/2" do
     test "unauthenticated requests get redirected to login", %{conn: conn} do
       conn = get(conn, ~p"/sign-in-export", %{"date" => "2024-08-28"})
 
       assert redirected_to(conn) == ~p"/login"
+    end
+
+    @tag :authenticated
+    test "returns CSV export", %{conn: conn} do
+      {:ok, signed_in_at, _offset} = DateTime.from_iso8601("2024-08-28T17:00:00-04:00")
+
+      insert(:operator_sign_in, %{signed_in_at: signed_in_at})
+
+      conn =
+        get(conn, ~p"/sign-in-export", %{
+          "date" => signed_in_at |> DateTime.to_date() |> Date.to_string()
+        })
+
+      csv = response(conn, :ok)
+
+      result =
+        csv
+        |> String.splitter("\n", trim: true)
+        |> Stream.map(&"#{&1}\n")
+        |> CSV.decode!(headers: true)
+        |> Enum.to_list()
+
+      assert [
+               %{
+                 "Location" => "Orient Heights",
+                 "Method" => "manual",
+                 "Signer Badge #" => "employee_badge0",
+                 "Signer Name" => "Preferredy Person",
+                 "Text Version" => "1",
+                 "Time" => "2024-08-28T17:00:00-04:00"
+               }
+             ] = result
+    end
+
+    @tag :authenticated
+    test "returns a bad request response for a malformed date", %{conn: conn} do
+      conn = get(conn, ~p"/sign-in-export", %{"date" => "invalid"})
+
+      assert text_response(conn, :bad_request)
     end
   end
 end

--- a/test/orbit_web/controllers/sign_in_export_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_export_controller_test.exs
@@ -30,16 +30,29 @@ defmodule OrbitWeb.SignInExportControllerTest do
       {:ok, signed_in_at1, _offset} = DateTime.from_iso8601("2024-08-28T17:00:00-04:00")
       {:ok, signed_in_at2, _offset} = DateTime.from_iso8601("2024-08-28T17:10:00-04:00")
 
+      official_user1 = insert(:user, %{email: "official1@mbta.com"})
+      official_user2 = insert(:user, %{email: "official2@mbta.com"})
+
+      insert(:employee, %{
+        first_name: "Fake",
+        preferred_first: nil,
+        last_name: "Official",
+        badge_number: "9898",
+        email: "official1@mbta.com"
+      })
+
       insert(:operator_sign_in, %{
         signed_in_at: signed_in_at1,
         sign_in_method: :manual,
-        signed_in_employee: build(:employee, %{badge_number: "1234"})
+        signed_in_employee: build(:employee, %{badge_number: "1234"}),
+        signed_in_by_user: official_user1
       })
 
       insert(:operator_sign_in, %{
         signed_in_at: signed_in_at2,
         sign_in_method: :nfc,
-        signed_in_employee: build(:employee, %{badge_number: "5678"})
+        signed_in_employee: build(:employee, %{badge_number: "5678"}),
+        signed_in_by_user: official_user2
       })
 
       filename =
@@ -63,6 +76,8 @@ defmodule OrbitWeb.SignInExportControllerTest do
                  "Method" => "type",
                  "Signer Badge #" => "1234",
                  "Signer Name" => "Preferredy Person",
+                 "Official Badge #" => "9898",
+                 "Official Name" => "Fake Official",
                  "Text Version" => "1",
                  "Time" => "2024-08-28 17:00:00"
                },
@@ -71,6 +86,8 @@ defmodule OrbitWeb.SignInExportControllerTest do
                  "Method" => "tap",
                  "Signer Badge #" => "5678",
                  "Signer Name" => "Preferredy Person",
+                 "Official Badge #" => "",
+                 "Official Name" => "official2@mbta.com",
                  "Text Version" => "1",
                  "Time" => "2024-08-28 17:10:00"
                }

--- a/test/orbit_web/controllers/sign_in_export_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_export_controller_test.exs
@@ -15,8 +15,17 @@ defmodule OrbitWeb.SignInExportControllerTest do
       {:ok, signed_in_at1, _offset} = DateTime.from_iso8601("2024-08-28T17:00:00-04:00")
       {:ok, signed_in_at2, _offset} = DateTime.from_iso8601("2024-08-28T17:10:00-04:00")
 
-      insert(:operator_sign_in, %{signed_in_at: signed_in_at1, sign_in_method: :manual})
-      insert(:operator_sign_in, %{signed_in_at: signed_in_at2, sign_in_method: :nfc})
+      insert(:operator_sign_in, %{
+        signed_in_at: signed_in_at1,
+        sign_in_method: :manual,
+        signed_in_employee: build(:employee, %{badge_number: "1234"})
+      })
+
+      insert(:operator_sign_in, %{
+        signed_in_at: signed_in_at2,
+        sign_in_method: :nfc,
+        signed_in_employee: build(:employee, %{badge_number: "5678"})
+      })
 
       conn =
         get(conn, ~p"/sign-in-export", %{
@@ -36,7 +45,7 @@ defmodule OrbitWeb.SignInExportControllerTest do
                %{
                  "Location" => "Orient Heights",
                  "Method" => "type",
-                 "Signer Badge #" => "employee_badge0",
+                 "Signer Badge #" => "1234",
                  "Signer Name" => "Preferredy Person",
                  "Text Version" => "1",
                  "Time" => "2024-08-28 17:00:00"
@@ -44,7 +53,7 @@ defmodule OrbitWeb.SignInExportControllerTest do
                %{
                  "Location" => "Orient Heights",
                  "Method" => "tap",
-                 "Signer Badge #" => "employee_badge1",
+                 "Signer Badge #" => "5678",
                  "Signer Name" => "Preferredy Person",
                  "Text Version" => "1",
                  "Time" => "2024-08-28 17:10:00"

--- a/test/orbit_web/controllers/sign_in_export_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_export_controller_test.exs
@@ -1,0 +1,11 @@
+defmodule OrbitWeb.SignInExportControllerTest do
+  use OrbitWeb.ConnCase
+
+  describe "get/2" do
+    test "unauthenticated requests get redirected to login", %{conn: conn} do
+      conn = get(conn, ~p"/sign-in-export", %{"date" => "2024-08-28"})
+
+      assert redirected_to(conn) == ~p"/login"
+    end
+  end
+end


### PR DESCRIPTION
Asana Task: [📐 Operator Compliance Export for tap and type](https://app.asana.com/0/1200273269966439/1206604036091421/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

I think there's a conversation to be had about how to best associate employees and users long-term, but for now I've opted to join them by email, since both tables have email on them and I've made sure that both have indexes on the email column. One thing to note for the future is that we _do not_ yet have a unique index on email in the employees table, but maybe we should?

One other thing I was considering is that there's at least some conceptual overlap between this and the `index` method on the `SignInController`, but the similarity in terms of code is actually only a couple / few lines of Ecto Query, so I'm not sure it's worth trying to unify those into one function.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(X)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
