### PR TITLE
refactor: look up badge number by rfid per request

### DIFF
--- a/js/api.ts
+++ b/js/api.ts
@@ -9,7 +9,7 @@ export type ApiResult<Result> =
   | { status: "ok"; result: Result }
   | { status: "error"; error?: unknown };
 
-export const post = (url: string, body: object) => {
+export const post = (url: string, body: object): Promise<Response> => {
   const csrfToken = getMetaContent("csrf-token");
   if (csrfToken === null) {
     throw new Error("Cannot POST; csrf-token was null");
@@ -24,6 +24,39 @@ export const post = (url: string, body: object) => {
   });
 };
 
+export const get = <RawData, Data>({
+  RawData,
+  url,
+  parser,
+}: {
+  RawData: z.ZodType<RawData>;
+  url: string;
+  parser: (data: RawData) => Data;
+}): Promise<Data> => {
+  return fetch(url)
+    .then((response) => {
+      if (response.status === 200) {
+        return response.json();
+      } else if (response.status === 401) {
+        reload();
+
+        throw new Error("Unauthenticated");
+      } else {
+        throw new Error(`Unrecognized response code: ${response.status}`);
+      }
+    })
+    .then((json) => {
+      const jsonObject = z.object({ data: z.unknown() }).parse(json);
+      const data = RawData.parse(jsonObject.data);
+      const parsedData = parser(data);
+      return parsedData;
+    })
+    .catch((e: unknown) => {
+      captureException(e);
+      throw e;
+    });
+};
+
 export const useApiResult = <RawData, Data>({
   RawData,
   url,
@@ -36,30 +69,12 @@ export const useApiResult = <RawData, Data>({
   const [result, setResult] = useState<ApiResult<Data>>({ status: "loading" });
 
   useEffect(() => {
-    fetch(url)
-      .then((response) => {
-        if (response.status === 200) {
-          return response.json();
-        } else if (response.status === 401) {
-          reload();
-
-          throw new Error("Unauthenticated");
-        } else {
-          throw new Error(`Unrecognized response code: ${response.status}`);
-        }
-      })
-      .then((json) => {
-        const jsonObject = z.object({ data: z.unknown() }).parse(json);
-
-        const data = RawData.parse(jsonObject.data);
-
-        const parsedData = parser(data);
-
+    get({ RawData, url, parser })
+      .then((parsedData) => {
         setResult({ status: "ok", result: parsedData });
       })
       .catch((e: unknown) => {
         setResult({ status: "error", error: e });
-        captureException(e);
       });
   }, [url, RawData, parser]);
 

--- a/js/components/operatorSignIn/attestation.tsx
+++ b/js/components/operatorSignIn/attestation.tsx
@@ -1,6 +1,6 @@
 import { ApiResult } from "../../api";
 import { reload } from "../../browser";
-import { findEmployeeByBadge } from "../../hooks/useEmployees";
+import { lookupDisplayName } from "../../hooks/useEmployees";
 import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
 import { useSignInText } from "./text";
@@ -37,11 +37,7 @@ export const Attestation = ({
       </div>
     );
   }
-  const employee = findEmployeeByBadge(employees.result, badge);
-  const name =
-    employee !== undefined ?
-      `${employee.preferred_first ?? employee.first_name} ${employee.last_name}`
-    : `Operator #${badge}`;
+  const name = lookupDisplayName(badge, employees.result);
   return (
     <div className="text-sm">
       Step 2 of 2

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -1,7 +1,5 @@
-import { ApiResult } from "../../api";
 import { fetchEmployeeByBadgeSerial } from "../../hooks/useEmployees";
 import { useNfc } from "../../hooks/useNfc";
-import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
 import { BadgeEntry } from "./types";
 import { ReactElement, useEffect, useId, useState } from "react";
@@ -11,13 +9,11 @@ export const OperatorSelection = ({
   onOK,
   onBadgeLookupError,
   onNfcScanError,
-  employees,
 }: {
   nfcSupported: boolean;
   onOK: (badgeEntry: BadgeEntry) => void;
   onBadgeLookupError: () => void;
   onNfcScanError: () => void;
-  employees: ApiResult<Employee[]>;
 }): ReactElement => {
   const inputId = useId();
   const [badgeEntry, setBadgeEntry] = useState<BadgeEntry | null>(null);
@@ -38,7 +34,7 @@ export const OperatorSelection = ({
     } else if (nfcResult.status === "error") {
       onNfcScanError();
     }
-  }, [nfcResult, employees, onOK, onBadgeLookupError, onNfcScanError]);
+  }, [nfcResult, onOK, onBadgeLookupError, onNfcScanError]);
 
   const buttonEnabled = badgeEntry !== null;
 

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -1,5 +1,5 @@
 import { ApiResult } from "../../api";
-import { findEmployeeByBadgeSerial } from "../../hooks/useEmployees";
+import { fetchEmployeeByBadgeSerial } from "../../hooks/useEmployees";
 import { useNfc } from "../../hooks/useNfc";
 import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
@@ -25,17 +25,16 @@ export const OperatorSelection = ({
   const { result: nfcResult } = useNfc();
 
   useEffect(() => {
-    if (nfcResult.status === "success" && employees.status === "ok") {
-      const badge = findEmployeeByBadgeSerial(
-        employees.result,
-        nfcResult.data,
-      )?.badge;
-
-      if (badge) {
-        onOK({ number: badge, method: "nfc" });
-      } else {
-        onBadgeLookupError();
-      }
+    if (nfcResult.status === "success") {
+      const badgeSerial = nfcResult.data;
+      fetchEmployeeByBadgeSerial(badgeSerial).then(
+        (badge) => {
+          onOK({ number: badge, method: "nfc" });
+        },
+        () => {
+          onBadgeLookupError();
+        },
+      );
     } else if (nfcResult.status === "error") {
       onNfcScanError();
     }

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -23,6 +23,8 @@ export const OperatorSelection = ({
   useEffect(() => {
     if (nfcResult.status === "success") {
       const badgeSerial = nfcResult.data;
+      // TODO potential race condition if something changes before the fetch returns?
+      // maybe not, cuz useNfc locks in the state on a scan result, but it should probably be defended against anyway
       fetchEmployeeByBadgeSerial(badgeSerial).then(
         (badge) => {
           onOK({ number: badge, method: "nfc" });

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -117,7 +117,6 @@ export const OperatorSignInModal = ({
           onNfcScanError={() => {
             setComplete(CompleteState.NFC_SCAN_ERROR);
           }}
-          employees={employees}
         />
       : <Attestation
           badge={badge.number}

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -80,10 +80,10 @@ export const OperatorSignInModal = ({
   }, [complete, close]);
 
   const employee =
-    employees.status === "ok" &&
-    badge !== null &&
-    findEmployeeByBadge(employees.result, badge.number);
-  const name = employee ? employee.first_name : `Operator ${badge?.number}`;
+    employees.status === "ok" && badge !== null ?
+      findEmployeeByBadge(employees.result, badge.number)
+    : null;
+  const name: string = employee?.first_name ?? `Operator ${badge?.number}`;
 
   return (
     <Modal

--- a/js/hooks/useEmployees.ts
+++ b/js/hooks/useEmployees.ts
@@ -28,7 +28,7 @@ export const lookupDisplayName = (badge: string, employees: Employee[]) => {
     return fallbackDisplayName(badge);
   }
 
-  return displayName(employee);
+  return displayName(employee) ?? fallbackDisplayName(badge);
 };
 
 export const findEmployeeByBadge = (employees: Employee[], badge: string) => {

--- a/js/hooks/useEmployees.ts
+++ b/js/hooks/useEmployees.ts
@@ -1,10 +1,11 @@
-import { useApiResult } from "../api";
+import { get, useApiResult } from "../api";
 import {
   displayName,
   Employee,
   EmployeeList,
   fallbackDisplayName,
 } from "../models/employee";
+import { z } from "zod";
 
 const EMPLOYEES_API_PATH = "/api/employees";
 
@@ -34,11 +35,15 @@ export const findEmployeeByBadge = (employees: Employee[], badge: string) => {
   return employees.find((employee) => employee.badge === badge);
 };
 
-export const findEmployeeByBadgeSerial = (
-  employees: Employee[],
+/**
+ * Promise will throw on 404 Not Found errors (in addition to other HTTP errors)
+ */
+export const fetchEmployeeByBadgeSerial = (
   badgeSerial: string,
-) => {
-  return employees.find((employee) =>
-    employee.badge_serials.includes(badgeSerial),
-  );
+): Promise<string> => {
+  return get({
+    RawData: z.string(),
+    url: `api/rfid?badge_serial=${badgeSerial}`,
+    parser: (s: string) => s,
+  });
 };

--- a/js/models/employee.ts
+++ b/js/models/employee.ts
@@ -1,17 +1,24 @@
 import { z } from "zod";
 
 export const Employee = z.object({
-  first_name: z.string(),
-  preferred_first: z.string().nullable(),
-  last_name: z.string(),
+  first_name: z.string().nullable(),
+  last_name: z.string().nullable(),
   badge: z.string(),
 });
 
-export const displayName = (emp: Employee) => {
-  return `${emp.preferred_first ?? emp.first_name} ${emp.last_name}`;
+export const displayName = (emp: Employee): string | null => {
+  if (emp.first_name && emp.last_name) {
+    return `${emp.first_name} ${emp.last_name}`;
+  } else if (emp.first_name) {
+    return emp.first_name;
+  } else if (emp.last_name) {
+    return emp.last_name;
+  } else {
+    return null;
+  }
 };
 
-export const fallbackDisplayName = (badge: string) => {
+export const fallbackDisplayName = (badge: string): string => {
   return `Operator #${badge}`;
 };
 

--- a/js/models/employee.ts
+++ b/js/models/employee.ts
@@ -5,7 +5,6 @@ export const Employee = z.object({
   preferred_first: z.string().nullable(),
   last_name: z.string(),
   badge: z.string(),
-  badge_serials: z.array(z.string()),
 });
 
 export const displayName = (emp: Employee) => {

--- a/js/test/components/operatorSignIn/list.test.tsx
+++ b/js/test/components/operatorSignIn/list.test.tsx
@@ -40,9 +40,7 @@ describe("List", () => {
     );
     expect(view.getByText("12:45 PM")).toBeInTheDocument();
     expect(
-      view.getByText(
-        `${EMPLOYEES[0].preferred_first} ${EMPLOYEES[0].last_name}`,
-      ),
+      view.getByText(`${EMPLOYEES[0].first_name} ${EMPLOYEES[0].last_name}`),
     ).toBeInTheDocument();
     expect(view.getByText("user@example.com")).toBeInTheDocument();
   });

--- a/js/test/components/operatorSignIn/list.test.tsx
+++ b/js/test/components/operatorSignIn/list.test.tsx
@@ -12,7 +12,6 @@ jest.mock("../../../hooks/useEmployees", () => ({
     result: EMPLOYEES,
   })),
   findEmployeeByBadge: jest.fn(() => EMPLOYEES[0]),
-  findEmployeeByBadgeSerial: jest.fn(() => EMPLOYEES[0]),
   lookupDisplayName: jest.fn(() => displayName(EMPLOYEES[0])),
 }));
 

--- a/js/test/components/operatorSignIn/operatorSelection.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSelection.test.tsx
@@ -1,20 +1,12 @@
-import { ApiResult } from "../../../api";
 import { OperatorSelection } from "../../../components/operatorSignIn/operatorSelection";
 import { fetchEmployeeByBadgeSerial } from "../../../hooks/useEmployees";
 import { useNfc } from "../../../hooks/useNfc";
-import { Employee } from "../../../models/employee";
-import { employeeFactory } from "../../helpers/factory";
 import {
   neverPromise,
   PromiseWithResolvers,
 } from "../../helpers/promiseWithResolvers";
 import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-const EMPLOYEES: ApiResult<Employee[]> = {
-  status: "ok",
-  result: [employeeFactory.build({ badge: "123" })],
-};
 
 jest.mock("../../../hooks/useNfc", () => ({
   __esModule: true,
@@ -36,7 +28,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={jest.fn()}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -50,7 +41,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={jest.fn()}
         onNfcScanError={jest.fn()}
         nfcSupported={false}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -66,7 +56,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={jest.fn()}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -83,7 +72,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={jest.fn()}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -108,7 +96,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={onBadgeLookupError}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -125,7 +112,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={onBadgeLookupError}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -151,7 +137,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={onBadgeLookupError}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -168,7 +153,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={onBadgeLookupError}
         onNfcScanError={jest.fn()}
         nfcSupported={true}
-        employees={{ ...EMPLOYEES, result: [] }}
       />,
     );
 
@@ -193,7 +177,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={onBadgeLookupError}
         onNfcScanError={onNfcScanError}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 
@@ -208,7 +191,6 @@ describe("OperatorSelection", () => {
         onBadgeLookupError={onBadgeLookupError}
         onNfcScanError={onNfcScanError}
         nfcSupported={true}
-        employees={EMPLOYEES}
       />,
     );
 

--- a/js/test/components/operatorSignIn/operatorSelection.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSelection.test.tsx
@@ -13,7 +13,7 @@ import userEvent from "@testing-library/user-event";
 
 const EMPLOYEES: ApiResult<Employee[]> = {
   status: "ok",
-  result: [employeeFactory.build({ badge: "123", badge_serials: ["56"] })],
+  result: [employeeFactory.build({ badge: "123" })],
 };
 
 jest.mock("../../../hooks/useNfc", () => ({

--- a/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
@@ -13,7 +13,9 @@ import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const EMPLOYEES = [employeeFactory.build()];
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock("../../../hooks/useEmployees", () => ({
+  ...jest.requireActual("../../../hooks/useEmployees"),
   useEmployees: jest.fn().mockImplementation(() => ({
     status: "ok",
     result: EMPLOYEES,

--- a/js/test/helpers/factory.ts
+++ b/js/test/helpers/factory.ts
@@ -2,8 +2,7 @@ import { Employee } from "../../models/employee";
 import { Factory } from "fishery";
 
 export const employeeFactory = Factory.define<Employee>(({ sequence }) => ({
-  first_name: "Firsty",
-  preferred_first: "Preferredy",
+  first_name: "Preferredy",
   last_name: "Lasty",
   badge: sequence.toString(),
 }));

--- a/js/test/helpers/factory.ts
+++ b/js/test/helpers/factory.ts
@@ -6,5 +6,4 @@ export const employeeFactory = Factory.define<Employee>(({ sequence }) => ({
   preferred_first: "Preferredy",
   last_name: "Lasty",
   badge: sequence.toString(),
-  badge_serials: [`serial${sequence.toString()}`],
 }));

--- a/js/test/hooks/useEmployees.test.ts
+++ b/js/test/hooks/useEmployees.test.ts
@@ -1,7 +1,7 @@
 import { fetch } from "../../browser";
 import {
+  fetchEmployeeByBadgeSerial,
   findEmployeeByBadge,
-  findEmployeeByBadgeSerial,
   lookupDisplayName,
   useEmployees,
 } from "../../hooks/useEmployees";
@@ -72,18 +72,31 @@ describe("findEmployeeByBadge", () => {
   });
 });
 
-describe("findEmployeeByBadgeSerial", () => {
-  test("finds an employee in an array by badge number", () => {
-    const employeeBadgeSerial = TEST_PARSED[0].badge_serials[0];
+describe("fetchEmployeeByBadgeSerial", () => {
+  test("finds an employee", async () => {
+    const { promise, resolve } = PromiseWithResolvers<Response>();
+    jest.mocked(fetch).mockReturnValue(promise);
 
-    expect(findEmployeeByBadgeSerial(TEST_PARSED, employeeBadgeSerial)).toEqual(
-      TEST_PARSED[0],
-    );
+    const result = fetchEmployeeByBadgeSerial("9999");
+
+    resolve({
+      status: 200,
+      json: () =>
+        new Promise((resolve) => {
+          resolve({ data: "123" });
+        }),
+    } as Response);
+
+    await expect(result).resolves.toBe("123");
   });
 
-  test("returns undefined if not found", () => {
-    expect(
-      findEmployeeByBadgeSerial(TEST_PARSED, "random_serial"),
-    ).toBeUndefined();
+  test("rejects if employee isn't found", async () => {
+    const { promise, resolve } = PromiseWithResolvers<Response>();
+    jest.mocked(fetch).mockReturnValue(promise);
+
+    const result = fetchEmployeeByBadgeSerial("9999");
+
+    resolve({ status: 404 } as Response);
+    await expect(result).toReject();
   });
 });

--- a/js/test/hooks/useEmployees.test.ts
+++ b/js/test/hooks/useEmployees.test.ts
@@ -14,12 +14,7 @@ jest.mock("../../browser", () => ({
 }));
 
 const TEST_DATA = {
-  data: [
-    employeeFactory.build(),
-    employeeFactory.build({
-      preferred_first: null,
-    }),
-  ],
+  data: [employeeFactory.build(), employeeFactory.build()],
 };
 
 const TEST_PARSED = TEST_DATA.data;

--- a/lib/orbit_web/controllers/employees_controller.ex
+++ b/lib/orbit_web/controllers/employees_controller.ex
@@ -11,8 +11,7 @@ defmodule OrbitWeb.EmployeesController do
         Repo.all(Employee),
         fn e ->
           %{
-            first_name: e.first_name,
-            preferred_first: e.preferred_first,
+            first_name: e.preferred_first || e.first_name,
             last_name: e.last_name,
             badge: e.badge_number
           }

--- a/lib/orbit_web/controllers/employees_controller.ex
+++ b/lib/orbit_web/controllers/employees_controller.ex
@@ -1,26 +1,20 @@
 defmodule OrbitWeb.EmployeesController do
-  alias Orbit.Employee
   use OrbitWeb, :controller
-  import Ecto.Query
 
+  alias Orbit.Employee
   alias Orbit.Repo
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     employees =
       Enum.map(
-        Repo.all(
-          from e in Employee,
-            left_join: b in assoc(e, :badge_serials),
-            preload: [badge_serials: b]
-        ),
+        Repo.all(Employee),
         fn e ->
           %{
             first_name: e.first_name,
             preferred_first: e.preferred_first,
             last_name: e.last_name,
-            badge: e.badge_number,
-            badge_serials: Enum.map(e.badge_serials, & &1.badge_serial)
+            badge: e.badge_number
           }
         end
       )

--- a/lib/orbit_web/controllers/rfid_controller.ex
+++ b/lib/orbit_web/controllers/rfid_controller.ex
@@ -5,6 +5,8 @@ defmodule OrbitWeb.RfidController do
 
   alias Orbit.Repo
 
+  # TODO once we have permissions, require sign in permissions in order to use this endpoint
+
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"badge_serial" => badge_serial}) do
     badge_number =

--- a/lib/orbit_web/controllers/rfid_controller.ex
+++ b/lib/orbit_web/controllers/rfid_controller.ex
@@ -1,0 +1,33 @@
+defmodule OrbitWeb.RfidController do
+  alias Orbit.BadgeSerial
+  use OrbitWeb, :controller
+  import Ecto.Query
+
+  alias Orbit.Repo
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, %{"badge_serial" => badge_serial}) do
+    badge_number =
+      Repo.one(
+        from b in BadgeSerial,
+          left_join: e in assoc(b, :employee),
+          where: b.badge_serial == ^badge_serial,
+          select: e.badge_number
+      )
+
+    if badge_number do
+      conn
+      |> json(%{data: badge_number})
+    else
+      conn
+      |> put_status(404)
+      |> text("Not found")
+    end
+  end
+
+  def show(conn, _params) do
+    conn
+    |> put_status(400)
+    |> text("Missing query param `badge_serial`")
+  end
+end

--- a/lib/orbit_web/router.ex
+++ b/lib/orbit_web/router.ex
@@ -61,6 +61,7 @@ defmodule OrbitWeb.Router do
     pipe_through :authenticated
 
     get "/api/employees", EmployeesController, :index
+    get "/api/rfid", RfidController, :show
     get "/api/signin", SignInController, :index
     post "/api/signin", SignInController, :submit
   end

--- a/test/orbit_web/controllers/employees_controller_test.exs
+++ b/test/orbit_web/controllers/employees_controller_test.exs
@@ -14,26 +14,7 @@ defmodule OrbitWeb.EmployeesControllerTest do
                    "badge" => _badge,
                    "first_name" => "Fake",
                    "last_name" => "Person",
-                   "preferred_first" => "Preferredy",
-                   "badge_serials" => [_badge_serial]
-                 }
-               ]
-             } = json_response(conn, 200)
-    end
-
-    @tag :authenticated
-    test "fetches employees without badge serial data", %{conn: conn} do
-      insert(:employee, %{badge_serials: []})
-      conn = get(conn, ~p"/api/employees")
-
-      assert %{
-               "data" => [
-                 %{
-                   "badge" => _badge,
-                   "first_name" => "Fake",
-                   "last_name" => "Person",
-                   "preferred_first" => "Preferredy",
-                   "badge_serials" => []
+                   "preferred_first" => "Preferredy"
                  }
                ]
              } = json_response(conn, 200)

--- a/test/orbit_web/controllers/employees_controller_test.exs
+++ b/test/orbit_web/controllers/employees_controller_test.exs
@@ -6,15 +6,20 @@ defmodule OrbitWeb.EmployeesControllerTest do
     @tag :authenticated
     test "fetches all employees", %{conn: conn} do
       insert(:employee)
+      insert(:employee, preferred_first: nil)
       conn = get(conn, ~p"/api/employees")
 
       assert %{
                "data" => [
                  %{
-                   "badge" => _badge,
+                   "badge" => _badge1,
+                   "first_name" => "Preferredy",
+                   "last_name" => "Person"
+                 },
+                 %{
+                   "badge" => _badge2,
                    "first_name" => "Fake",
-                   "last_name" => "Person",
-                   "preferred_first" => "Preferredy"
+                   "last_name" => "Person"
                  }
                ]
              } = json_response(conn, 200)

--- a/test/orbit_web/controllers/rfid_controller_test.exs
+++ b/test/orbit_web/controllers/rfid_controller_test.exs
@@ -1,0 +1,27 @@
+defmodule OrbitWeb.RfidControllerTest do
+  use OrbitWeb.ConnCase
+  import Orbit.Factory
+
+  @moduletag :authenticated
+
+  describe "index" do
+    test "fetches badge_number by badge_serial", %{conn: conn} do
+      insert(:employee,
+        badge_number: "123",
+        badge_serials: [
+          build(:badge_serial, badge_serial: "9999"),
+          build(:badge_serial, badge_serial: "9998")
+        ]
+      )
+
+      conn = get(conn, ~p"/api/rfid?badge_serial=9998")
+      assert %{"data" => "123"} = json_response(conn, 200)
+    end
+
+    test "returns 404 if serial doesn't exist", %{conn: conn} do
+      insert(:employee, badge_serials: [])
+      conn = get(conn, ~p"/api/rfid?badge_serial=9998")
+      assert response(conn, 404)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,7 +16,7 @@ defmodule Orbit.Factory do
       middle_initial: "A",
       email: sequence(:employee_email, &"fake#{&1}@test.com"),
       badge_number: sequence("employee_badge"),
-      badge_serials: [build(:badge_serial)],
+      badge_serials: [],
       area: 321
     }
   end


### PR DESCRIPTION
Asana Task: Noticed during [📐 Orbit: allow manually associating a badge serial with an operator for testing](https://app.asana.com/0/1200689710863995/1207890347662644/f), discussed in slack.

Instead of sending all badge_serials to the frontend with the employee data, this PR makes a new api endpoint to look them up one by one during sign in.

I'll need help testing this on sandbox (but I see sandbox is in use right now).

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed