### PR TITLE
refactor: frontend employee name fields

### DIFF
--- a/js/components/operatorSignIn/attestation.tsx
+++ b/js/components/operatorSignIn/attestation.tsx
@@ -1,6 +1,6 @@
 import { ApiResult } from "../../api";
 import { reload } from "../../browser";
-import { findEmployeeByBadge } from "../../hooks/useEmployees";
+import { lookupDisplayName } from "../../hooks/useEmployees";
 import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
 import { useSignInText } from "./text";
@@ -37,11 +37,7 @@ export const Attestation = ({
       </div>
     );
   }
-  const employee = findEmployeeByBadge(employees.result, badge);
-  const name =
-    employee !== undefined ?
-      `${employee.preferred_first ?? employee.first_name} ${employee.last_name}`
-    : `Operator #${badge}`;
+  const name = lookupDisplayName(badge, employees.result);
   return (
     <div className="text-sm">
       Step 2 of 2

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -80,10 +80,10 @@ export const OperatorSignInModal = ({
   }, [complete, close]);
 
   const employee =
-    employees.status === "ok" &&
-    badge !== null &&
-    findEmployeeByBadge(employees.result, badge.number);
-  const name = employee ? employee.first_name : `Operator ${badge?.number}`;
+    employees.status === "ok" && badge !== null ?
+      findEmployeeByBadge(employees.result, badge.number)
+    : null;
+  const name: string = employee?.first_name ?? `Operator ${badge?.number}`;
 
   return (
     <Modal

--- a/js/hooks/useEmployees.ts
+++ b/js/hooks/useEmployees.ts
@@ -28,7 +28,7 @@ export const lookupDisplayName = (badge: string, employees: Employee[]) => {
     return fallbackDisplayName(badge);
   }
 
-  return displayName(employee);
+  return displayName(employee) ?? fallbackDisplayName(badge);
 };
 
 export const findEmployeeByBadge = (employees: Employee[], badge: string) => {

--- a/js/models/employee.ts
+++ b/js/models/employee.ts
@@ -1,17 +1,24 @@
 import { z } from "zod";
 
 export const Employee = z.object({
-  first_name: z.string(),
-  preferred_first: z.string().nullable(),
-  last_name: z.string(),
+  first_name: z.string().nullable(),
+  last_name: z.string().nullable(),
   badge: z.string(),
 });
 
-export const displayName = (emp: Employee) => {
-  return `${emp.preferred_first ?? emp.first_name} ${emp.last_name}`;
+export const displayName = (emp: Employee): string | null => {
+  if (emp.first_name && emp.last_name) {
+    return `${emp.first_name} ${emp.last_name}`;
+  } else if (emp.first_name) {
+    return emp.first_name;
+  } else if (emp.last_name) {
+    return emp.last_name;
+  } else {
+    return null;
+  }
 };
 
-export const fallbackDisplayName = (badge: string) => {
+export const fallbackDisplayName = (badge: string): string => {
   return `Operator #${badge}`;
 };
 

--- a/js/test/components/operatorSignIn/list.test.tsx
+++ b/js/test/components/operatorSignIn/list.test.tsx
@@ -40,9 +40,7 @@ describe("List", () => {
     );
     expect(view.getByText("12:45 PM")).toBeInTheDocument();
     expect(
-      view.getByText(
-        `${EMPLOYEES[0].preferred_first} ${EMPLOYEES[0].last_name}`,
-      ),
+      view.getByText(`${EMPLOYEES[0].first_name} ${EMPLOYEES[0].last_name}`),
     ).toBeInTheDocument();
     expect(view.getByText("user@example.com")).toBeInTheDocument();
   });

--- a/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
@@ -13,7 +13,9 @@ import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const EMPLOYEES = [employeeFactory.build()];
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock("../../../hooks/useEmployees", () => ({
+  ...jest.requireActual("../../../hooks/useEmployees"),
   useEmployees: jest.fn().mockImplementation(() => ({
     status: "ok",
     result: EMPLOYEES,

--- a/js/test/helpers/factory.ts
+++ b/js/test/helpers/factory.ts
@@ -2,8 +2,7 @@ import { Employee } from "../../models/employee";
 import { Factory } from "fishery";
 
 export const employeeFactory = Factory.define<Employee>(({ sequence }) => ({
-  first_name: "Firsty",
-  preferred_first: "Preferredy",
+  first_name: "Preferredy",
   last_name: "Lasty",
   badge: sequence.toString(),
 }));

--- a/js/test/hooks/useEmployees.test.ts
+++ b/js/test/hooks/useEmployees.test.ts
@@ -14,12 +14,7 @@ jest.mock("../../browser", () => ({
 }));
 
 const TEST_DATA = {
-  data: [
-    employeeFactory.build(),
-    employeeFactory.build({
-      preferred_first: null,
-    }),
-  ],
+  data: [employeeFactory.build(), employeeFactory.build()],
 };
 
 const TEST_PARSED = TEST_DATA.data;

--- a/lib/orbit_web/controllers/employees_controller.ex
+++ b/lib/orbit_web/controllers/employees_controller.ex
@@ -11,8 +11,7 @@ defmodule OrbitWeb.EmployeesController do
         Repo.all(Employee),
         fn e ->
           %{
-            first_name: e.first_name,
-            preferred_first: e.preferred_first,
+            first_name: e.preferred_first || e.first_name,
             last_name: e.last_name,
             badge: e.badge_number
           }

--- a/test/orbit_web/controllers/employees_controller_test.exs
+++ b/test/orbit_web/controllers/employees_controller_test.exs
@@ -6,15 +6,20 @@ defmodule OrbitWeb.EmployeesControllerTest do
     @tag :authenticated
     test "fetches all employees", %{conn: conn} do
       insert(:employee)
+      insert(:employee, preferred_first: nil)
       conn = get(conn, ~p"/api/employees")
 
       assert %{
                "data" => [
                  %{
-                   "badge" => _badge,
+                   "badge" => _badge1,
+                   "first_name" => "Preferredy",
+                   "last_name" => "Person"
+                 },
+                 %{
+                   "badge" => _badge2,
                    "first_name" => "Fake",
-                   "last_name" => "Person",
-                   "preferred_first" => "Preferredy"
+                   "last_name" => "Person"
                  }
                ]
              } = json_response(conn, 200)


### PR DESCRIPTION
Asana Task: None. Noticed while doing #104

Stacked on top of #104.

Things this changes:
- first and last name can be nil on the backend, but the frontend assumed they'd always be there. This PR makes them nullable and handles if they're missing.
- The non-preferred first name isn't used on the frontend, so might as well not send it at all, for better privacy and so the frontend doesn't have to juggle the two of them.
- Except for the one spot we accidentally did use first_name instead of preferred_first. Now it'll use the preferred name if available.
- DRYs one place where `lookupDisplayName` was reimplemented.

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed
