### PR TITLE
test: eslint should error instead of warn

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,7 @@ export default tseslint.config(
   {
     name: "orbit",
     linterOptions: {
-      reportUnusedDisableDirectives: "warn",
+      reportUnusedDisableDirectives: "error",
     },
     languageOptions: {
       globals: globals.browser,
@@ -62,10 +62,10 @@ export default tseslint.config(
       // allow modifying module.exports
       "better-mutation/no-mutation": ["error", { commonjs: true }],
       // enforce "type" instead of enforcing "interface"
-      "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
       // unused arguments are fine if they have a leading _
       "@typescript-eslint/no-unused-vars": [
-        "warn",
+        "error",
         {
           argsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",


### PR DESCRIPTION
Asana Task: None

I ran into a lint warning that didn't cause eslint to return an error code, which means it would have been able to sneak past CI. Turns out eslint warnings are intended for things that you don't have to fix immediately, like if you're gradually linting a legacy codebase. Everything here should be errors.

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
