### PR TITLE
fix: move modal interaction state so it's conditionally rendered

### DIFF
--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -1,5 +1,6 @@
-import { post } from "../../api";
+import { ApiResult, post } from "../../api";
 import { findEmployeeByBadge, useEmployees } from "../../hooks/useEmployees";
+import { EmployeeList } from "../../models/employee";
 import { nfcSupported } from "../../util/nfc";
 import { Modal } from "../modal";
 import { Attestation } from "./attestation";
@@ -60,12 +61,32 @@ export const OperatorSignInModal = ({
   show: boolean;
   close: () => void;
 }): ReactElement => {
+  const employees = useEmployees();
+
+  return (
+    <Modal
+      show={show}
+      title={<span className="text-lg font-bold">Fit for Duty Check</span>}
+      onClose={() => {
+        close();
+      }}
+    >
+      <OperatorSignInModalContent employees={employees} close={close} />
+    </Modal>
+  );
+};
+
+const OperatorSignInModalContent = ({
+  employees,
+  close,
+}: {
+  employees: ApiResult<EmployeeList>;
+  close: () => void;
+}): ReactElement => {
   const [badge, setBadge] = useState<BadgeEntry | null>(null);
   const [complete, setComplete] = useState<CompleteState | null>(null);
 
   const [loading, setLoading] = useState<boolean>(false);
-
-  const employees = useEmployees();
 
   // Hide modal after timer on success
   useEffect(() => {
@@ -86,13 +107,7 @@ export const OperatorSignInModal = ({
   const name = employee ? employee.first_name : `Operator ${badge?.number}`;
 
   return (
-    <Modal
-      show={show}
-      title={<span className="text-lg font-bold">Fit for Duty Check</span>}
-      onClose={() => {
-        close();
-      }}
-    >
+    <>
       {complete === CompleteState.SIGN_IN_ERROR && badge !== null ?
         <SignInError
           name={name}
@@ -128,6 +143,6 @@ export const OperatorSignInModal = ({
           employees={employees}
         />
       }
-    </Modal>
+    </>
   );
 };

--- a/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSignInModal.test.tsx
@@ -127,4 +127,32 @@ describe("OperatorSignInModal", () => {
       view.getByText(/something went wrong when looking for a badge tap/i),
     ).toBeInTheDocument();
   });
+
+  test("reopening modal after a successful sign-in resets to the original state", async () => {
+    putMetaData("csrf-token", "TEST-CSRF-TOKEN");
+    jest.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+    } as Response);
+
+    const close = jest.fn();
+
+    const view = render(<OperatorSignInModal show={true} close={close} />);
+
+    await userEvent.type(view.getByRole("textbox"), "123");
+
+    await userEvent.click(view.getByRole("button", { name: "OK" }));
+
+    await userEvent.type(view.getByRole("textbox"), "123");
+    await userEvent.click(
+      view.getByRole("button", { name: "Complete Fit for Duty Check" }),
+    );
+
+    expect(view.getByText(/signed in successfully/i)).toBeInTheDocument();
+
+    view.rerender(<OperatorSignInModal show={false} close={close} />);
+
+    view.rerender(<OperatorSignInModal show={true} close={close} />);
+
+    expect(view.getByText(/waiting for badge tap/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Asana Task: [🛠 Orbit sign in flow for multiple people in series](https://app.asana.com/0/1200273269966439/1208045647859192/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

As expected, all that ended up being necessary here was moving some React state around so that it's in a component that's conditionally rendered when the modal is open, and therefore gets reset if the modal is closed and reopened.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(X)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
