### PR TITLE
unique badge serials

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,11 +33,6 @@ config :orbit, Oban,
 
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
-# Logging config
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
-
 config :phoenix,
   # Use Jason for JSON parsing in Phoenix
   json_library: Jason,

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,6 +34,7 @@ config :orbit, Orbit.Import.Personnel, pathname: "personnel/demo.csv"
 config :orbit, Orbit.Import.Rfid, pathname: "rfid/demo.csv"
 
 config :logger, level: :warning
+config :logger, :console, format: "[$level] $message\n"
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/lib/orbit/badge_serial.ex
+++ b/lib/orbit/badge_serial.ex
@@ -20,6 +20,7 @@ defmodule Orbit.BadgeSerial do
     badge_serial
     |> cast(attrs, [:badge_serial])
     |> validate_required([:badge_serial])
+    |> unique_constraint(:badge_serial)
     |> foreign_key_constraint(:employee_id)
   end
 end

--- a/lib/orbit_web/controllers/admin/admin_controller.ex
+++ b/lib/orbit_web/controllers/admin/admin_controller.ex
@@ -96,7 +96,10 @@ defmodule OrbitWeb.Admin.AdminController do
         badge_serial: badge_serial
       }
       |> BadgeSerial.changeset()
-      |> Repo.insert!()
+      |> Repo.insert!(
+        on_conflict: {:replace_all_except, [:id, :inserted_at]},
+        conflict_target: :badge_serial
+      )
 
       text(conn, "OK")
     else

--- a/priv/repo/migrations/20240830184718_badge_serial_unique_index.exs
+++ b/priv/repo/migrations/20240830184718_badge_serial_unique_index.exs
@@ -1,0 +1,13 @@
+defmodule Orbit.Repo.Migrations.BadgeSerialUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "DELETE FROM badge_serials a USING badge_serials b WHERE a.id <> b.id AND a.badge_serial = b.badge_serial",
+      ""
+    )
+
+    drop index(:badge_serials, [:badge_serial])
+    create unique_index(:badge_serials, [:badge_serial])
+  end
+end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -15,4 +15,30 @@ defmodule Test.Support.Helpers do
       end)
     end
   end
+
+  @doc """
+  returns a list of strings with newline at the end trimmed
+  """
+  defmacro capture_log(level \\ :info, do: expression) do
+    quote do
+      require Logger
+      original_level = Logger.level()
+      on_exit(fn -> Logger.configure(level: original_level) end)
+      Logger.configure(level: unquote(level))
+
+      {"", lines} =
+        ExUnit.CaptureLog.capture_log([colors: [enabled: false]], fn ->
+          unquote(expression)
+        end)
+        |> String.split("\n")
+        |> List.pop_at(-1)
+
+      # Reset the log level for the rest of the test.
+      # The on_exit above is needed for cleanup in case of a crash,
+      # but it runs when the test is done, not when this macro is done
+      Logger.configure(level: original_level)
+
+      lines
+    end
+  end
 end


### PR DESCRIPTION
Asana Task: [📐 Orbit: allow manually associating a badge serial with an operator for testing](https://app.asana.com/0/1200689710863995/1207890347662644/f)

Migration to make badge serials unique, and updates to the two ways to create badge serials (/admin/rfid and the csv import) to enforce that.

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
