### PR TITLE
feat: Mask more data display from FullStory

### DIFF
--- a/js/components/operatorSignIn/list.tsx
+++ b/js/components/operatorSignIn/list.tsx
@@ -33,10 +33,10 @@ export const List = ({ line }: { line: HeavyRailLine }): ReactElement => {
         </tr>
         {signIns.result.map((si, idx) => (
           <tr key={idx}>
-            <td className="border-y md:border-x p-1">
+            <td className="fs-mask border-y md:border-x p-1">
               {lookupDisplayName(si.signed_in_employee, employees.result)}
             </td>
-            <td className="border-y md:border-x p-1 break-all">
+            <td className="fs-mask border-y md:border-x p-1 break-all">
               {si.signed_in_employee}
             </td>
             <td className="border-y md:border-x p-1">
@@ -44,7 +44,7 @@ export const List = ({ line }: { line: HeavyRailLine }): ReactElement => {
                 .toLocaleString(DateTime.TIME_SIMPLE)
                 .replace(/ /g, "")}
             </td>
-            <td className="border-y md:border-x p-1 break-words [hyphenate-character:'']">
+            <td className="fs-mask border-y md:border-x p-1 break-words [hyphenate-character:'']">
               {si.signed_in_by_user.replace(
                 /@/g,
                 // 173 is a soft hyphen, which here acts as a breaking suggestion

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -48,7 +48,7 @@ export const OperatorSelection = ({
       <Or />
       <label htmlFor={inputId}>Search for an Operator</label>
       <input
-        className="h-10"
+        className="fs-mask h-10"
         id={inputId}
         inputMode="numeric"
         onChange={(evt) => {


### PR DESCRIPTION
Asana Task: [🛠 Install Fullstory](https://app.asana.com/0/1200273269966439/1207316362183269/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

To finish off FullStory installation, I'm masking more operator names and badge numbers from capture.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
