### PR TITLE
fix: don't raise on invalid employee during signin

### DIFF
--- a/test/orbit_web/controllers/sign_in_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_controller_test.exs
@@ -144,14 +144,15 @@ defmodule OrbitWeb.SignInControllerTest do
 
     @tag :authenticated
     test "replies 404 when the employee does not exist", %{conn: conn} do
-      assert_error_sent 404, fn ->
+      conn =
         post(conn, ~p"/api/signin", %{
           "signed_in_employee_badge" => "DOES_NOT_EXIST",
           "signed_in_at" => 1_721_164_459,
           "line" => "blue",
           "method" => "manual"
         })
-      end
+
+      assert "Employee not found" = response(conn, 404)
     end
   end
 end


### PR DESCRIPTION
Asana Task: [🐞 Orbit Ecto.NoResultsError on invalid badge entry](https://app.asana.com/0/1200882337457260/1208298977479188/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Sentry noise from this is untenable, so let's just not raise.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
