### PR TITLE
fix: Prevent List component from erroring on displaying errors

### DIFF
--- a/js/api.ts
+++ b/js/api.ts
@@ -74,6 +74,7 @@ export const useApiResult = <RawData, Data>({
         setResult({ status: "ok", result: parsedData });
       })
       .catch((e: unknown) => {
+        console.error(e);
         setResult({ status: "error", error: e });
       });
   }, [url, RawData, parser]);

--- a/js/components/operatorSignIn/list.tsx
+++ b/js/components/operatorSignIn/list.tsx
@@ -11,9 +11,9 @@ export const List = ({ line }: { line: HeavyRailLine }): ReactElement => {
   if (signIns.status === "loading" || employees.status === "loading") {
     return <>Loading...</>;
   } else if (signIns.status === "error") {
-    return <>Error retrieving signins: {signIns.error}</>;
+    return <>Error retrieving signins.</>;
   } else if (employees.status === "error") {
-    return <>Error retrieving employees: {employees.error}</>;
+    return <>Error retrieving employees.</>;
   }
 
   return (


### PR DESCRIPTION
Asana Task: [🐞 Orbit react error after Chrome quit on Android](https://app.asana.com/0/1206105669438487/1208214593975946/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

The errors coming from `useSignins` via `useApiResult` are Objects, which React won't display as a node (understandably). So I could have string concatenated them with `+` to get them to display regardless, but meh. Let's just `console.error` (which we can retrieve via other means) and display nothing to the end user.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests **This is removing functionality that didn't work in the first place..**
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
