### PR TITLE
feat: osi list shows officials' name with email as fallback

### DIFF
--- a/js/components/operatorSignIn/list.tsx
+++ b/js/components/operatorSignIn/list.tsx
@@ -45,7 +45,7 @@ export const List = ({ line }: { line: HeavyRailLine }): ReactElement => {
                 .replace(/ /g, "")}
             </td>
             <td className="fs-mask border-y md:border-x p-1 break-words [hyphenate-character:'']">
-              {si.signed_in_by_user.replace(
+              {si.signed_in_by.replace(
                 /@/g,
                 // 173 is a soft hyphen, which here acts as a breaking suggestion
                 // We are hiding the hyphen above with CSS

--- a/js/models/signin.ts
+++ b/js/models/signin.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const SignIn = z.object({
   rail_line: z.enum(["blue", "orange", "red"]),
   signed_in_at: z.string(),
-  signed_in_by_user: z.string(),
+  signed_in_by: z.string(),
   signed_in_employee: z.string(),
 });
 

--- a/js/test/components/operatorSignIn/list.test.tsx
+++ b/js/test/components/operatorSignIn/list.test.tsx
@@ -24,7 +24,7 @@ jest.mock("../../../hooks/useSignIns", () => ({
         signed_in_at: DateTime.fromISO("2024-07-22T12:45:52.000-04:00", {
           zone: "America/New_York",
         }),
-        signed_in_by_user: "user@example.com",
+        signed_in_by: "user@example.com",
         signed_in_employee: EMPLOYEES[0].badge,
       },
     ],

--- a/js/test/hooks/useSignins.test.ts
+++ b/js/test/hooks/useSignins.test.ts
@@ -13,7 +13,7 @@ const TEST_DATA = {
     {
       rail_line: "blue",
       signed_in_at: "2024-07-22T16:42:32Z",
-      signed_in_by_user: "user@example.com",
+      signed_in_by: "user@example.com",
       signed_in_employee: "123",
     },
   ],

--- a/lib/orbit_web/controllers/sign_in_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_controller.ex
@@ -31,8 +31,9 @@ defmodule OrbitWeb.SignInController do
                 ^start_datetime <= si.signed_in_at and
                   si.signed_in_at < ^end_datetime and
                   si.rail_line == ^rail_line,
+              join: e in assoc(si, :signed_in_employee),
               join: u in assoc(si, :signed_in_by_user),
-              preload: [:signed_in_employee, signed_in_by_user: u],
+              preload: [signed_in_employee: e, signed_in_by_user: u],
               left_join: signed_in_by_employee in Employee,
               on: u.email == signed_in_by_employee.email,
               order_by: [desc: :signed_in_at],


### PR DESCRIPTION
Asana Task: [📐 Orbit: In-app view of completed sign-ins does not include official full name](https://app.asana.com/0/1206105669438487/1208171871591943/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Display officials' names in the list, with email address as fallback.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
