### PR TITLE
fix(Employee): Use official's email address if names are blank

### DIFF
--- a/lib/orbit/employee.ex
+++ b/lib/orbit/employee.ex
@@ -51,7 +51,10 @@ defmodule Orbit.Employee do
 
   @spec display_name(t()) :: String.t()
   def display_name(employee) do
-    "#{employee.preferred_first || employee.first_name} #{employee.last_name}"
+    case String.trim("#{employee.preferred_first || employee.first_name} #{employee.last_name}") do
+      "" -> employee.email
+      name -> name
+    end
   end
 
   @spec get_by_badge_serial(String.t()) :: t() | nil

--- a/test/orbit/employee_test.exs
+++ b/test/orbit/employee_test.exs
@@ -61,6 +61,18 @@ defmodule Orbit.EmployeeTest do
 
       assert Employee.display_name(employee) == "First Name"
     end
+
+    test "uses email if names are all blank" do
+      employee =
+        build(:employee, %{
+          preferred_first: nil,
+          first_name: "",
+          last_name: "",
+          email: "rawr@example.com"
+        })
+
+      assert Employee.display_name(employee) == "rawr@example.com"
+    end
   end
 
   describe "get_by_badge_serial/1" do

--- a/test/orbit_web/controllers/sign_in_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_controller_test.exs
@@ -106,36 +106,6 @@ defmodule OrbitWeb.SignInControllerTest do
     end
 
     @tag :authenticated
-    test "shows official's email address if employee names are empty string", %{conn: conn} do
-      emp =
-        insert(:employee, %{
-          first_name: "",
-          preferred_first: nil,
-          last_name: "",
-          email: "exists_but_employee_names_are_blank@example.com"
-        })
-
-      insert(:operator_sign_in,
-        signed_in_at: DateTime.new!(~D[2024-07-21], ~T[12:00:00], @timezone),
-        signed_in_employee: emp,
-        signed_in_by_user:
-          build(:user, %{
-            email: "exists_but_employee_names_are_blank@example.com"
-          })
-      )
-
-      conn = get(conn, ~p"/api/signin", %{"line" => "blue", "service_date" => "2024-07-21"})
-
-      assert %{
-               "data" => [
-                 %{
-                   "signed_in_by" => "exists_but_employee_names_are_blank@example.com"
-                 }
-               ]
-             } = json_response(conn, 200)
-    end
-
-    @tag :authenticated
     test "sorted by signed_in_at descending (recent first)", %{conn: conn} do
       insert(:operator_sign_in,
         signed_in_at: DateTime.new!(~D[2024-07-21], ~T[12:00:00], @timezone)

--- a/test/orbit_web/controllers/sign_in_controller_test.exs
+++ b/test/orbit_web/controllers/sign_in_controller_test.exs
@@ -106,6 +106,36 @@ defmodule OrbitWeb.SignInControllerTest do
     end
 
     @tag :authenticated
+    test "shows official's email address if employee names are empty string", %{conn: conn} do
+      emp =
+        insert(:employee, %{
+          first_name: "",
+          preferred_first: nil,
+          last_name: "",
+          email: "exists_but_employee_names_are_blank@example.com"
+        })
+
+      insert(:operator_sign_in,
+        signed_in_at: DateTime.new!(~D[2024-07-21], ~T[12:00:00], @timezone),
+        signed_in_employee: emp,
+        signed_in_by_user:
+          build(:user, %{
+            email: "exists_but_employee_names_are_blank@example.com"
+          })
+      )
+
+      conn = get(conn, ~p"/api/signin", %{"line" => "blue", "service_date" => "2024-07-21"})
+
+      assert %{
+               "data" => [
+                 %{
+                   "signed_in_by" => "exists_but_employee_names_are_blank@example.com"
+                 }
+               ]
+             } = json_response(conn, 200)
+    end
+
+    @tag :authenticated
     test "sorted by signed_in_at descending (recent first)", %{conn: conn} do
       insert(:operator_sign_in,
         signed_in_at: DateTime.new!(~D[2024-07-21], ~T[12:00:00], @timezone)


### PR DESCRIPTION
Asana Task: [🐞 [employee] is weird in Orbit](https://app.asana.com/0/1200882337457260/1208356829197703/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

See task^'s comments. Changing so email is substituted in if name data from HR/CMS is blank.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
