### PR TITLE
fix(OperatorSelection): ignore leading zeroes

### DIFF
--- a/js/components/operatorSignIn/attestation.tsx
+++ b/js/components/operatorSignIn/attestation.tsx
@@ -158,6 +158,7 @@ export const SignaturePrompt = ({
           className="fs-mask w-full"
           inputMode="numeric"
           defaultValue={defaultValue}
+          // Do not set `value`- we are transforming below!
           onChange={(evt) => {
             onChange(removeLeadingZero(evt.target.value));
           }}

--- a/js/components/operatorSignIn/attestation.tsx
+++ b/js/components/operatorSignIn/attestation.tsx
@@ -3,6 +3,7 @@ import { reload } from "../../browser";
 import { lookupDisplayName } from "../../hooks/useEmployees";
 import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
+import { removeLeadingZero } from "../../util/string";
 import { useSignInText } from "./text";
 import { ReactElement, useEffect, useState } from "react";
 
@@ -158,7 +159,7 @@ export const SignaturePrompt = ({
           inputMode="numeric"
           defaultValue={defaultValue}
           onChange={(evt) => {
-            onChange(evt.target.value);
+            onChange(removeLeadingZero(evt.target.value));
           }}
           required
         />

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -1,6 +1,7 @@
 import { fetchEmployeeByBadgeSerial } from "../../hooks/useEmployees";
 import { useNfc } from "../../hooks/useNfc";
 import { className } from "../../util/dom";
+import { removeLeadingZero } from "../../util/string";
 import { BadgeEntry } from "./types";
 import { ReactElement, useEffect, useId, useState } from "react";
 
@@ -52,7 +53,10 @@ export const OperatorSelection = ({
         id={inputId}
         inputMode="numeric"
         onChange={(evt) => {
-          setBadgeEntry({ number: evt.target.value, method: "manual" });
+          setBadgeEntry({
+            number: removeLeadingZero(evt.target.value),
+            method: "manual",
+          });
         }}
       />
       <button

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -52,6 +52,7 @@ export const OperatorSelection = ({
         className="fs-mask h-10"
         id={inputId}
         inputMode="numeric"
+        // Do not set `value`- we are transforming below!
         onChange={(evt) => {
           setBadgeEntry({
             number: removeLeadingZero(evt.target.value),

--- a/js/test/components/operatorSignIn/attestation.test.tsx
+++ b/js/test/components/operatorSignIn/attestation.test.tsx
@@ -116,6 +116,26 @@ describe("Attestation", () => {
     expect(onComplete).toHaveBeenCalledOnce();
   });
 
+  test("valid attestation with leading zero", async () => {
+    const onComplete = jest.fn();
+    const view = render(
+      <Attestation
+        badge="123"
+        prefill={false}
+        onComplete={onComplete}
+        loading={false}
+        employees={EMPLOYEES}
+      />,
+    );
+    await userEvent.type(view.getByRole("textbox"), "0123");
+    expect(view.getByText("Looks good!")).toBeInTheDocument();
+
+    await userEvent.click(
+      view.getByRole("button", { name: "Complete Fit for Duty Check" }),
+    );
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
   test("invalid attestation", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     jest.useFakeTimers();

--- a/js/test/components/operatorSignIn/operatorSelection.test.tsx
+++ b/js/test/components/operatorSignIn/operatorSelection.test.tsx
@@ -86,6 +86,28 @@ describe("OperatorSelection", () => {
     });
   });
 
+  test("trims leading zeros from typed operator badge", async () => {
+    const onOK = jest.fn();
+    const view = render(
+      <OperatorSelection
+        onOK={onOK}
+        onBadgeLookupError={jest.fn()}
+        onNfcScanError={jest.fn()}
+        nfcSupported={true}
+      />,
+    );
+
+    const textField = view.getByRole("textbox");
+    const button = view.getByRole("button");
+    await userEvent.type(textField, "0123");
+    await userEvent.click(button);
+
+    expect(onOK).toHaveBeenCalledExactlyOnceWith({
+      number: "123",
+      method: "manual",
+    });
+  });
+
   test("executes onOK on successful badge tap", async () => {
     const onOK = jest.fn();
     const onBadgeLookupError = jest.fn();

--- a/js/util/string.ts
+++ b/js/util/string.ts
@@ -1,0 +1,3 @@
+export const removeLeadingZero = (str: string) => {
+  return str.replace(/^0+/, "");
+};


### PR DESCRIPTION
Asana Task: [Allow leading zero in Orbit type workaround](https://app.asana.com/0/1206105669438487/1208362994470250/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Ignore leading zero in operator selection & attestation, as we cannot tell what personnel are used to.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
