### PR TITLE
fix(operatorSelection): fix Enter/Go key with <form>

### DIFF
--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -42,7 +42,12 @@ export const OperatorSelection = ({
   const buttonEnabled = badgeEntry !== null;
 
   return (
-    <div className="flex flex-col content-stretch">
+    <form
+      className="flex flex-col content-stretch"
+      onSubmit={(e) => {
+        e.preventDefault();
+      }}
+    >
       {nfcSupported ?
         <NfcSupported />
       : <NfcUnsupported />}
@@ -79,7 +84,7 @@ export const OperatorSelection = ({
       >
         OK
       </button>
-    </div>
+    </form>
   );
 };
 

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -44,8 +44,12 @@ export const OperatorSelection = ({
   return (
     <form
       className="flex flex-col content-stretch"
-      onSubmit={(e) => {
-        e.preventDefault();
+      onSubmit={() => {
+        if (badgeEntry === null) {
+          throw new Error("operatorSelection badgeEntry was impossibly null.");
+        }
+
+        onOK(badgeEntry);
       }}
     >
       {nfcSupported ?
@@ -67,16 +71,6 @@ export const OperatorSelection = ({
       />
       <button
         disabled={!buttonEnabled}
-        onClick={() => {
-          // This should never happen, but throw just in case.
-          if (badgeEntry === null) {
-            throw new Error(
-              "operatorSelection badgeEntry was impossibly null.",
-            );
-          }
-
-          onOK(badgeEntry);
-        }}
         className={className([
           "rounded bg-gray-500 text-gray-200 mt-3 w-full md:max-w-64 mx-auto h-10",
           !buttonEnabled && "opacity-50",

--- a/js/components/operatorSignIn/operatorSelection.tsx
+++ b/js/components/operatorSignIn/operatorSelection.tsx
@@ -44,7 +44,8 @@ export const OperatorSelection = ({
   return (
     <form
       className="flex flex-col content-stretch"
-      onSubmit={() => {
+      onSubmit={(e) => {
+        e.preventDefault();
         if (badgeEntry === null) {
           throw new Error("operatorSelection badgeEntry was impossibly null.");
         }


### PR DESCRIPTION
Asana Task: None

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

In #164 I fixed the Enter/Go key on the Attestation by switching to an HTML `<form>`; doing it here for OperatorSelection too.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
