### PR TITLE
chore: quiet console.error in passing api.test.ts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -95,6 +95,8 @@ export default tseslint.config(
       "@typescript-eslint/no-empty-function": "off",
       // expect.any is untyped and triggers this all the time.
       "@typescript-eslint/no-unsafe-assignment": "off",
+      // sometimes the easiest way to mock a complex test setup is to mutate something
+      "better-mutation/no-mutation": "off",
       /* we do `view = render(); view.getBy()` which also doesn't require destructuring
       and has less global mutable state than `screen`. */
       "testing-library/prefer-screen-queries": "off",

--- a/js/test/api.test.ts
+++ b/js/test/api.test.ts
@@ -123,6 +123,14 @@ describe("get", () => {
 });
 
 describe("useApiResult", () => {
+  let spyConsoleError: jest.SpiedFunction<typeof console.error>;
+  beforeEach(() => {
+    spyConsoleError = jest.spyOn(console, "error");
+  });
+  afterEach(() => {
+    spyConsoleError.mockRestore();
+  });
+
   test("returns loading state", () => {
     const RawData = z.string();
     const parser = (s: string) => s;
@@ -167,8 +175,10 @@ describe("useApiResult", () => {
     const RawData = z.string();
     const parser = (s: string) => s;
 
-    const { promise, resolve } = PromiseWithResolvers<Response>();
+    // this test triggers console.error. quiet it.
+    spyConsoleError.mockImplementationOnce(() => {});
 
+    const { promise, resolve } = PromiseWithResolvers<Response>();
     jest.mocked(fetch).mockReturnValue(promise);
 
     const { result } = renderHook(useApiResult, {
@@ -192,8 +202,10 @@ describe("useApiResult", () => {
     const RawData = z.string();
     const parser = (s: string) => s;
 
-    const { promise, resolve } = PromiseWithResolvers<Response>();
+    // this test triggers console.error. quiet it.
+    spyConsoleError.mockImplementationOnce(() => {});
 
+    const { promise, resolve } = PromiseWithResolvers<Response>();
     jest.mocked(fetch).mockReturnValue(promise);
 
     const { result } = renderHook(useApiResult, {
@@ -218,8 +230,10 @@ describe("useApiResult", () => {
     const RawData = z.string();
     const parser = (s: string) => s;
 
-    const { promise, resolve } = PromiseWithResolvers<Response>();
+    // this test triggers console.error. quiet it.
+    spyConsoleError.mockImplementationOnce(() => {});
 
+    const { promise, resolve } = PromiseWithResolvers<Response>();
     jest.mocked(fetch).mockReturnValue(promise);
 
     const { result } = renderHook(useApiResult, {

--- a/js/test/helpers/metadata.ts
+++ b/js/test/helpers/metadata.ts
@@ -1,4 +1,3 @@
-/* eslint-disable better-mutation/no-mutation */
 import { MetaDataKey } from "../../util/metadata";
 
 export const putMetaData = (key: MetaDataKey, value: string) => {

--- a/js/test/helpers/promiseWithResolvers.ts
+++ b/js/test/helpers/promiseWithResolvers.ts
@@ -20,9 +20,7 @@ export const PromiseWithResolvers = <T>(): {
   let resolve: ((value: T | PromiseLike<T>) => void) | undefined = undefined;
   let reject: ((reason?: unknown) => void) | undefined = undefined;
   const promise = new Promise<T>((res, rej) => {
-    // eslint-disable-next-line better-mutation/no-mutation
     resolve = res;
-    // eslint-disable-next-line better-mutation/no-mutation
     reject = rej;
   });
 


### PR DESCRIPTION
Asana Task: None

This has been bugging me for a while, passing tests shouldn't print error messages. I finally spent 15 minutes to fix it.

Before:
<img width="626" alt="Screenshot 2024-12-16 at 09 44 12" src="https://github.com/user-attachments/assets/725aab57-c88d-4160-aa2f-44ed24301911" />


After:
<img width="742" alt="Screenshot 2024-12-16 at 09 51 28" src="https://github.com/user-attachments/assets/9627fb7b-3170-483d-b3df-6c4216f1025a" />


- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
