### PR TITLE
fix: update red-200. remove unused red-100

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,7 +35,7 @@ export default {
       green: "#145A06",
       orange: "#ED8B00",
       red: {
-        200: "#FF4531"
+        200: "#FF4531",
       },
       white: "#ffffff",
       yellow: "#FFC961",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,8 +35,7 @@ export default {
       green: "#145A06",
       orange: "#ED8B00",
       red: {
-        100: "#DA291C",
-        200: "#B3000F",
+        200: "#FF4531"
       },
       white: "#ffffff",
       yellow: "#FFC961",


### PR DESCRIPTION
Asana Task: [Update the red color in Glides + Orbit](https://app.asana.com/0/1208918247656304/1208002952543253/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Description goes here.
Include screenshots if relevant.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->

Note:
The red-100 color is not used and so this PR removes it.

Before: 
![orbit_before](https://github.com/user-attachments/assets/4b3ec9b5-8cab-42f3-9b76-25b27df12820)
<br>
After:
![orbit_after](https://github.com/user-attachments/assets/8434139b-c375-4d10-8927-c7b2f10d6fc3)


