### PR TITLE
fix: RailLine enum option :none replaces nil + truncate certifications

### DIFF
--- a/lib/orbit/certification.ex
+++ b/lib/orbit/certification.ex
@@ -10,7 +10,7 @@ defmodule Orbit.Certification do
   @type t :: %__MODULE__{
           badge: String.t(),
           type: certification_type(),
-          rail_line: RailLine.t() | nil,
+          rail_line: RailLine.t(),
           expires: Date.t()
         }
   schema "certifications" do

--- a/lib/orbit/import/certifications.ex
+++ b/lib/orbit/import/certifications.ex
@@ -44,7 +44,7 @@ defmodule Orbit.Import.ImportCertifications do
             :red
 
           true ->
-            nil
+            :none
         end
 
       %Certification{
@@ -60,7 +60,7 @@ defmodule Orbit.Import.ImportCertifications do
     end)
     |> Enum.each(
       &Repo.insert(&1,
-        on_conflict: :replace_all,
+        on_conflict: {:replace_all_except, [:id, :inserted_at]},
         conflict_target: [:badge, :type, :rail_line]
       )
     )

--- a/lib/orbit/rail_line.ex
+++ b/lib/orbit/rail_line.ex
@@ -1,20 +1,24 @@
 defmodule Orbit.RailLine do
   use Ecto.Type
 
-  @type t :: :red | :orange | :blue
+  # NB preston: we use 'none' instead of db NULL here so upserts continue to work
+  # TODO PostgreSQL 15.x: Switch to db NULL
+  @type t :: :red | :orange | :blue | :none
 
   @impl true
   def type, do: :string
 
   @impl true
-  def cast(line) when line in [:red, :orange, :blue], do: {:ok, line}
+  def cast(line) when line in [:red, :orange, :blue, :none], do: {:ok, line}
   def cast(_), do: :error
 
   @impl true
-  def load(line) when line in ["red", "orange", "blue"], do: {:ok, String.to_existing_atom(line)}
+  def load(line) when line in ["red", "orange", "blue", "none"],
+    do: {:ok, String.to_existing_atom(line)}
+
   def load(_), do: :error
 
   @impl true
-  def dump(line) when line in [:red, :orange, :blue], do: {:ok, Atom.to_string(line)}
+  def dump(line) when line in [:red, :orange, :blue, :none], do: {:ok, Atom.to_string(line)}
   def dump(_), do: :error
 end

--- a/priv/repo/migrations/20250106153058_truncate_certifications.exs
+++ b/priv/repo/migrations/20250106153058_truncate_certifications.exs
@@ -1,0 +1,7 @@
+defmodule Orbit.Repo.Migrations.TruncateCertifications do
+  use Ecto.Migration
+
+  def change do
+    execute "DELETE FROM certifications"
+  end
+end

--- a/priv/repo/migrations/20250106164510_rail_line_add_unknown.exs
+++ b/priv/repo/migrations/20250106164510_rail_line_add_unknown.exs
@@ -1,0 +1,7 @@
+defmodule Orbit.Repo.Migrations.CertificationRailLineUnknown do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TYPE rail_line ADD VALUE 'none';"
+  end
+end

--- a/priv/repo/migrations/20250106164510_rail_line_add_unknown.exs
+++ b/priv/repo/migrations/20250106164510_rail_line_add_unknown.exs
@@ -3,5 +3,9 @@ defmodule Orbit.Repo.Migrations.CertificationRailLineUnknown do
 
   def change do
     execute "ALTER TYPE rail_line ADD VALUE 'none';"
+
+    alter table(:certifications) do
+      modify :rail_line, :rail_line, null: false
+    end
   end
 end

--- a/test/orbit/import/certifications_test.exs
+++ b/test/orbit/import/certifications_test.exs
@@ -119,7 +119,7 @@ defmodule Orbit.Import.CertificationsTest do
              ] = Repo.all(from(c in Certification, order_by: [desc: :expires]))
     end
 
-    test "missing rail line becomes nil" do
+    test "missing rail line becomes :none" do
       rows = [
         %{
           "User - User ID" => "01234",
@@ -132,7 +132,7 @@ defmodule Orbit.Import.CertificationsTest do
 
       assert [
                %Certification{
-                 rail_line: nil
+                 rail_line: :none
                }
              ] = Repo.all(from(c in Certification))
     end


### PR DESCRIPTION
Asana Task: [📐 Implement Warnings for Expiring Certifications](https://app.asana.com/0/1206105669438487/1208729753338210/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

I made the assumption in my earlier Orbit changes to import certifications that Postgres treats nulls as a singleton, i.e. they violate unique constraints and would trigger an upsert. But that isn't available until PostgreSQL 15.x :-( It's possible to do with multiple partial indexes, but with downstream downsides. I think this is better.

⚠️ THIS CONTAINS A MIGRATION THAT TRUNCATES `certifications`.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
