### PR TITLE
fix(certifications): filter out certifications that aren't relevant for BL signin

### DIFF
--- a/js/components/operatorSignIn/attestation.tsx
+++ b/js/components/operatorSignIn/attestation.tsx
@@ -1,6 +1,6 @@
 import { useNow } from "../../dateTime";
 import { lookupDisplayName } from "../../hooks/useEmployees";
-import { Certification, getExpired } from "../../models/certification";
+import { Certification, filterExpired } from "../../models/certification";
 import { Employee } from "../../models/employee";
 import { className } from "../../util/dom";
 import { removeLeadingZero } from "../../util/string";
@@ -32,7 +32,7 @@ export const Attestation = ({
   const [bypass, setBypass] = useState<boolean>(false);
 
   const name = lookupDisplayName(badge, employees);
-  const expireds = getExpired(certifications, now);
+  const expireds = filterExpired(certifications, now);
 
   return (
     <div className="text-sm">

--- a/js/components/operatorSignIn/operatorSignInModal.tsx
+++ b/js/components/operatorSignIn/operatorSignInModal.tsx
@@ -3,7 +3,7 @@ import { reload } from "../../browser";
 import { useNow } from "../../dateTime";
 import { useCertifications } from "../../hooks/useCertifications";
 import { findEmployeeByBadge, useEmployees } from "../../hooks/useEmployees";
-import { Certification, getExpired } from "../../models/certification";
+import { Certification, filterExpired } from "../../models/certification";
 import { EmployeeList } from "../../models/employee";
 import { nfcSupported } from "../../util/nfc";
 import { Modal } from "../modal";
@@ -108,7 +108,7 @@ const OperatorSignInModalContent = ({
   const [loading, setLoading] = useState<boolean>(false);
 
   const now = useNow("second");
-  const certifications = useCertifications(badge?.number ?? null);
+  const certifications = useCertifications(badge?.number ?? null, "blue");
 
   // Hide modal after timer on success
   useEffect(() => {
@@ -157,7 +157,7 @@ const OperatorSignInModalContent = ({
             submit(
               badge,
               radio,
-              getExpired(certifications.result, now),
+              filterExpired(certifications.result, now),
               setComplete,
               setLoading,
               onComplete,
@@ -190,7 +190,7 @@ const OperatorSignInModalContent = ({
             submit(
               badge,
               radio,
-              getExpired(certifications.result, now),
+              filterExpired(certifications.result, now),
               setComplete,
               setLoading,
               onComplete,

--- a/js/hooks/useCertifications.ts
+++ b/js/hooks/useCertifications.ts
@@ -3,7 +3,7 @@ import {
   Certification,
   CertificationDataList,
   certificationFromData,
-  filterRelevantForOperator,
+  filterRelevantForOperators,
 } from "../models/certification";
 import { HeavyRailLine } from "../types";
 import { useCallback } from "react";
@@ -16,7 +16,7 @@ export const useCertifications = (
 ): ApiResult<Certification[]> => {
   const parse = useCallback(
     (data: CertificationDataList) => {
-      return filterRelevantForOperator(data.map(certificationFromData), line);
+      return filterRelevantForOperators(data.map(certificationFromData), line);
     },
     [line],
   );

--- a/js/hooks/useCertifications.ts
+++ b/js/hooks/useCertifications.ts
@@ -3,17 +3,23 @@ import {
   Certification,
   CertificationDataList,
   certificationFromData,
+  filterRelevantForOperator,
 } from "../models/certification";
+import { HeavyRailLine } from "../types";
+import { useCallback } from "react";
 
 const CERTIFICATIONS_API_PATH = "/api/certifications";
 
-const parse = (list: CertificationDataList) => {
-  return list.map(certificationFromData);
-};
-
 export const useCertifications = (
   badge: string | null,
+  line: HeavyRailLine,
 ): ApiResult<Certification[]> => {
+  const parse = useCallback(
+    (data: CertificationDataList) => {
+      return filterRelevantForOperator(data.map(certificationFromData), line);
+    },
+    [line],
+  );
   return useApiResult({
     RawData: CertificationDataList,
     url: `${CERTIFICATIONS_API_PATH}?badge=${badge}`,

--- a/js/models/certification.ts
+++ b/js/models/certification.ts
@@ -1,15 +1,16 @@
+import { HeavyRailLine } from "../types";
 import { DateTime } from "luxon";
 import { z } from "zod";
 
 export type Certification = {
   type: string;
-  railLine: string;
+  railLine: HeavyRailLine;
   expires: DateTime;
 };
 
 export const CertificationData = z.object({
   type: z.string(),
-  rail_line: z.string(),
+  rail_line: HeavyRailLine,
   expires: z.string(),
 });
 export type CertificationData = z.infer<typeof CertificationData>;
@@ -29,7 +30,20 @@ export const isExpired = (c: Certification, now: DateTime) => {
   return now >= c.expires.startOf("day");
 };
 
-export const getExpired = (cs: Certification[] | undefined, now: DateTime) => {
+export const filterRelevantForOperator = (
+  cs: Certification[],
+  line: HeavyRailLine,
+) => {
+  return cs.filter(
+    (c) =>
+      (c.type === "rail" && c.railLine === line) || c.type === "right_of_way",
+  );
+};
+
+export const filterExpired = (
+  cs: Certification[] | undefined,
+  now: DateTime,
+) => {
   if (cs === undefined) {
     return [];
   }
@@ -40,7 +54,7 @@ export const anyOfExpired = (
   cs: Certification[] | undefined,
   now: DateTime,
 ) => {
-  return getExpired(cs, now).length > 0;
+  return filterExpired(cs, now).length > 0;
 };
 
 export const humanReadableType = (type: string): string => {

--- a/js/models/certification.ts
+++ b/js/models/certification.ts
@@ -30,7 +30,7 @@ export const isExpired = (c: Certification, now: DateTime) => {
   return now >= c.expires.startOf("day");
 };
 
-export const filterRelevantForOperator = (
+export const filterRelevantForOperators = (
   cs: Certification[],
   line: HeavyRailLine,
 ) => {

--- a/js/models/certification.ts
+++ b/js/models/certification.ts
@@ -36,7 +36,8 @@ export const filterRelevantForOperators = (
 ) => {
   return cs.filter(
     (c) =>
-      (c.type === "rail" && c.railLine === line) || c.type === "right_of_way",
+      (c.type === "rail" && c.railLine === line) || // Rail cert: line must match
+      (c.type === "right_of_way" && [line, "none"].includes(c.railLine)), // ROW cert: must be 'none' or same line
   );
 };
 

--- a/js/test/hooks/useCertifications.test.ts
+++ b/js/test/hooks/useCertifications.test.ts
@@ -1,14 +1,23 @@
 import { fetch } from "../../browser";
 import { useCertifications } from "../../hooks/useCertifications";
+import { filterRelevantForOperator } from "../../models/certification";
 import {
   certificationDataFactory,
   certificationFactory,
 } from "../helpers/factory";
 import { PromiseWithResolvers } from "../helpers/promiseWithResolvers";
 import { renderHook, waitFor } from "@testing-library/react";
+import { DateTime } from "luxon";
 
 jest.mock("../../browser", () => ({
   fetch: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock("../../models/certification", () => ({
+  ...jest.requireActual("../../models/certification"),
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  filterRelevantForOperator: jest.fn((cs, _line) => cs),
 }));
 
 const TEST_DATA = {
@@ -22,7 +31,7 @@ describe("useCertifications", () => {
     const { promise, resolve } = PromiseWithResolvers<Response>();
     jest.mocked(fetch).mockReturnValue(promise);
 
-    const { result } = renderHook(useCertifications);
+    const { result } = renderHook(() => useCertifications("1234", "blue"));
 
     resolve({
       status: 200,
@@ -34,6 +43,36 @@ describe("useCertifications", () => {
 
     await waitFor(() => {
       expect(result.current).toEqual({ status: "ok", result: TEST_PARSED });
+    });
+  });
+
+  test("calls filterRelevantForOperator", async () => {
+    const { promise, resolve } = PromiseWithResolvers<Response>();
+    jest.mocked(fetch).mockReturnValue(promise);
+
+    const line = "blue";
+
+    renderHook(() => useCertifications("1234", line));
+
+    resolve({
+      status: 200,
+      json: () =>
+        new Promise((resolve) => {
+          resolve(TEST_DATA);
+        }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(filterRelevantForOperator).toHaveBeenCalledWith(
+        [
+          {
+            expires: expect.any(DateTime),
+            railLine: "blue",
+            type: "rail",
+          },
+        ],
+        line,
+      );
     });
   });
 });

--- a/js/test/hooks/useCertifications.test.ts
+++ b/js/test/hooks/useCertifications.test.ts
@@ -1,6 +1,6 @@
 import { fetch } from "../../browser";
 import { useCertifications } from "../../hooks/useCertifications";
-import { filterRelevantForOperator } from "../../models/certification";
+import { filterRelevantForOperators } from "../../models/certification";
 import {
   certificationDataFactory,
   certificationFactory,
@@ -17,7 +17,7 @@ jest.mock("../../browser", () => ({
 jest.mock("../../models/certification", () => ({
   ...jest.requireActual("../../models/certification"),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  filterRelevantForOperator: jest.fn((cs, _line) => cs),
+  filterRelevantForOperators: jest.fn((cs, _line) => cs),
 }));
 
 const TEST_DATA = {
@@ -46,7 +46,7 @@ describe("useCertifications", () => {
     });
   });
 
-  test("calls filterRelevantForOperator", async () => {
+  test("calls filterRelevantForOperators", async () => {
     const { promise, resolve } = PromiseWithResolvers<Response>();
     jest.mocked(fetch).mockReturnValue(promise);
 
@@ -63,7 +63,7 @@ describe("useCertifications", () => {
     } as Response);
 
     await waitFor(() => {
-      expect(filterRelevantForOperator).toHaveBeenCalledWith(
+      expect(filterRelevantForOperators).toHaveBeenCalledWith(
         [
           {
             expires: expect.any(DateTime),

--- a/js/test/models/certification.test.ts
+++ b/js/test/models/certification.test.ts
@@ -71,4 +71,18 @@ describe("filterRelevantForOperators", () => {
       ),
     ).toHaveLength(1);
   });
+
+  test("ignore ROW cert OL for BL", () => {
+    expect(
+      filterRelevantForOperators(
+        [
+          certificationFactory.build({
+            railLine: "orange",
+            type: "right_of_way",
+          }),
+        ],
+        "blue",
+      ),
+    ).toHaveLength(0);
+  });
 });

--- a/js/test/models/certification.test.ts
+++ b/js/test/models/certification.test.ts
@@ -1,10 +1,10 @@
-import { filterRelevantForOperator } from "../../models/certification";
+import { filterRelevantForOperators } from "../../models/certification";
 import { certificationFactory } from "../helpers/factory";
 
-describe("filterRelevantForOperator", () => {
+describe("filterRelevantForOperators", () => {
   test("keep rail cert for BL", () => {
     expect(
-      filterRelevantForOperator(
+      filterRelevantForOperators(
         [
           certificationFactory.build({
             railLine: "blue",
@@ -18,7 +18,7 @@ describe("filterRelevantForOperator", () => {
 
   test("ignore rail cert OL when BL", () => {
     expect(
-      filterRelevantForOperator(
+      filterRelevantForOperators(
         [
           certificationFactory.build({
             railLine: "orange",
@@ -32,7 +32,7 @@ describe("filterRelevantForOperator", () => {
 
   test("ignore rail cert for none line when BL", () => {
     expect(
-      filterRelevantForOperator(
+      filterRelevantForOperators(
         [
           certificationFactory.build({
             railLine: "none",
@@ -46,7 +46,7 @@ describe("filterRelevantForOperator", () => {
 
   test("keep ROW cert with none line for BL", () => {
     expect(
-      filterRelevantForOperator(
+      filterRelevantForOperators(
         [
           certificationFactory.build({
             railLine: "none",
@@ -60,7 +60,7 @@ describe("filterRelevantForOperator", () => {
 
   test("keep ROW cert with blue line for BL", () => {
     expect(
-      filterRelevantForOperator(
+      filterRelevantForOperators(
         [
           certificationFactory.build({
             railLine: "blue",

--- a/js/test/models/certification.test.ts
+++ b/js/test/models/certification.test.ts
@@ -1,0 +1,74 @@
+import { filterRelevantForOperator } from "../../models/certification";
+import { certificationFactory } from "../helpers/factory";
+
+describe("filterRelevantForOperator", () => {
+  test("keep rail cert for BL", () => {
+    expect(
+      filterRelevantForOperator(
+        [
+          certificationFactory.build({
+            railLine: "blue",
+            type: "rail",
+          }),
+        ],
+        "blue",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("ignore rail cert OL when BL", () => {
+    expect(
+      filterRelevantForOperator(
+        [
+          certificationFactory.build({
+            railLine: "orange",
+            type: "rail",
+          }),
+        ],
+        "blue",
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("ignore rail cert for none line when BL", () => {
+    expect(
+      filterRelevantForOperator(
+        [
+          certificationFactory.build({
+            railLine: "none",
+            type: "rail",
+          }),
+        ],
+        "blue",
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("keep ROW cert with none line for BL", () => {
+    expect(
+      filterRelevantForOperator(
+        [
+          certificationFactory.build({
+            railLine: "none",
+            type: "right_of_way",
+          }),
+        ],
+        "blue",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("keep ROW cert with blue line for BL", () => {
+    expect(
+      filterRelevantForOperator(
+        [
+          certificationFactory.build({
+            railLine: "blue",
+            type: "right_of_way",
+          }),
+        ],
+        "blue",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/js/types.ts
+++ b/js/types.ts
@@ -1,1 +1,4 @@
-export type HeavyRailLine = "blue" | "orange" | "red";
+import { z } from "zod";
+
+export const HeavyRailLine = z.enum(["blue", "orange", "red", "none"]);
+export type HeavyRailLine = z.infer<typeof HeavyRailLine>;


### PR DESCRIPTION
Asana Task: [📐 Implement Warnings for Expiring Certifications](https://app.asana.com/0/1206105669438487/1208729753338210/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Mix of a feature and a fix. Filter out certifications for other lines, so that:
1. (feature) we only evaluate BL operators against BL certifications. will make RL and OL easier.
2. (fix) old rail certifications in the data that are lineless (don't match the format) are filtered out.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
