### PR TITLE
connect to socket and reload if out of date or unauthenticated

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,10 +97,15 @@ export default tseslint.config(
       ...pluginTestingLibrary.configs["flat/react"].rules,
       // empty functions are fine
       "@typescript-eslint/no-empty-function": "off",
+      // ! is fine in tests
+      "@typescript-eslint/no-non-null-assertion": "off",
       // expect.any is untyped and triggers this all the time.
       "@typescript-eslint/no-unsafe-assignment": "off",
+      // expect(method) triggers this
+      "@typescript-eslint/unbound-method": "off",
       // sometimes the easiest way to mock a complex test setup is to mutate something
       "better-mutation/no-mutation": "off",
+      "better-mutation/no-mutating-methods": "off",
       /* we do `view = render(); view.getBy()` which also doesn't require destructuring
       and has less global mutable state than `screen`. */
       "testing-library/prefer-screen-queries": "off",

--- a/js/app.tsx
+++ b/js/app.tsx
@@ -2,7 +2,10 @@
 import "./telemetry";
 import "./phoenix.js";
 import { App } from "./components/app.js";
+import { initSocket } from "./socket";
 import { createRoot } from "react-dom/client";
+
+initSocket();
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(document.getElementById("app")!);

--- a/js/socket.ts
+++ b/js/socket.ts
@@ -40,8 +40,8 @@ export const initSocket = () => {
         console.warn(response);
       })
       .receive("error", (response: unknown) => {
-        console.warn("channel error");
-        console.warn(response);
+        console.error("channel error");
+        console.error(response);
       });
   });
 

--- a/js/socket.ts
+++ b/js/socket.ts
@@ -1,0 +1,54 @@
+import { reload } from "./browser";
+import { getMetaContent } from "./util/metadata";
+import { Socket } from "phoenix";
+import { z } from "zod";
+
+export const initSocket = () => {
+  const clientRelease = getMetaContent("release");
+  const socket = new Socket("/socket", {
+    params: {
+      release: clientRelease,
+      token: getMetaContent("guardianToken"),
+    },
+  });
+
+  socket.onError((_error, _transport, _establishedConnections) => {
+    console.warn("socket error");
+  });
+
+  socket.onOpen(() => {
+    socket
+      .channel("metadata")
+      .join()
+      .receive("ok", (rawResponse: unknown) => {
+        const { authenticated, server_release: serverRelease } =
+          MetadataJoinResponse.parse(rawResponse);
+        if (serverRelease !== clientRelease) {
+          console.warn(
+            `Server has version ${serverRelease} but we have version ${clientRelease}. Reloading.`,
+          );
+          reload();
+        }
+        if (!authenticated) {
+          console.warn("Authentication failed. Reloading.");
+          reload();
+        }
+        // channel successfully joined
+      })
+      .receive("timeout", (response: unknown) => {
+        console.warn("channel timeout");
+        console.warn(response);
+      })
+      .receive("error", (response: unknown) => {
+        console.warn("channel error");
+        console.warn(response);
+      });
+  });
+
+  socket.connect();
+};
+
+const MetadataJoinResponse = z.object({
+  authenticated: z.boolean(),
+  server_release: z.string(),
+});

--- a/js/test/helpers/socket.ts
+++ b/js/test/helpers/socket.ts
@@ -1,0 +1,84 @@
+import { Channel, Push, PushStatus, Socket } from "phoenix";
+
+export const makeMockSocket = (): {
+  socket: jest.Mocked<Socket>;
+  onOpen: () => void;
+  onError: () => void;
+  getChannel: (topic: string) => ReturnType<typeof makeMockChannel> | null;
+} => {
+  const onOpenCallbacks: Parameters<Socket["onOpen"]>[0][] = [];
+  const onErrorCallbacks: Parameters<Socket["onError"]>[0][] = [];
+  const channelsByTopic: Record<
+    string,
+    ReturnType<typeof makeMockChannel>
+  > = {};
+  const socket = {
+    onOpen: jest.fn((callback) => {
+      onOpenCallbacks.push(callback);
+      return "MessageRef";
+    }),
+    onError: jest.fn((callback) => {
+      onErrorCallbacks.push(callback);
+      return "MessageRef";
+    }),
+    channel: jest.fn((topic: string, _chanParams?: object) => {
+      const mockChannel = makeMockChannel();
+      channelsByTopic[topic] = mockChannel;
+      return mockChannel.channel;
+    }),
+    connect: jest.fn(),
+  } as Partial<Socket> as jest.Mocked<Socket>;
+  return {
+    socket,
+    onOpen: () => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- we only use synchronous callbacks here
+      onOpenCallbacks.forEach((onOpen) => onOpen());
+    },
+    onError: () => {
+      // @ts-expect-error -- wrong args for onError, but the real types are complex and not used anyway
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- we only use synchronous callbacks here
+      onErrorCallbacks.forEach((onError) => onError("event", "transport", 0));
+    },
+    getChannel: (topic: string) => channelsByTopic[topic] ?? null,
+  };
+};
+
+export const makeMockChannel = (): {
+  channel: jest.Mocked<Channel>;
+  joinReceive: (status: PushStatus, response: unknown) => void;
+} => {
+  const { push: joinPush, receive: joinReceive } = makeMockPush();
+  const channel = {
+    join: jest.fn(() => joinPush),
+  } as Partial<Channel> as jest.Mocked<Channel>;
+  return {
+    channel,
+    joinReceive: joinReceive,
+  };
+};
+
+const makeMockPush = (): {
+  push: jest.Mocked<Push>;
+  receive: (status: PushStatus, response: unknown) => void;
+} => {
+  const callbacks: [PushStatus, (response: unknown) => unknown][] = [];
+  const push = {
+    receive: (
+      status: PushStatus,
+      callback: (response?: unknown) => unknown,
+    ) => {
+      callbacks.push([status, callback]);
+      return push;
+    },
+  } as jest.Mocked<Push>;
+  return {
+    push,
+    receive: (status: PushStatus, response: unknown) => {
+      callbacks.forEach(([callbackStatus, callback]) => {
+        if (callbackStatus === status) {
+          callback(response);
+        }
+      });
+    },
+  };
+};

--- a/js/test/hooks/useNfc.test.ts
+++ b/js/test/hooks/useNfc.test.ts
@@ -85,7 +85,6 @@ describe("useNfc", () => {
 
     const { result, unmount } = renderHook(useNfc);
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const abortSpy = jest.spyOn(result.current.abortController!, "abort");
 
     unmount();
@@ -99,7 +98,6 @@ describe("useNfc", () => {
     const { result } = renderHook(useNfc);
 
     act(() => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       result.current.abortController!.abort();
     });
 

--- a/js/test/setupTest.ts
+++ b/js/test/setupTest.ts
@@ -5,7 +5,9 @@ import * as jestExtendedMatchers from "jest-extended";
 
 expect.extend(jestExtendedMatchers);
 
+// always prevent these side-effects from being called in tests
 jest.mock("../browser", () => ({
   fetch: jest.fn(() => neverPromise()),
   reload: jest.fn(),
 }));
+jest.mock("phoenix");

--- a/js/test/socket.test.ts
+++ b/js/test/socket.test.ts
@@ -1,0 +1,81 @@
+import { reload } from "../browser";
+import { initSocket } from "../socket";
+import { MetaDataKey } from "../util/metadata";
+import { makeMockSocket } from "./helpers/socket";
+import { Socket } from "phoenix";
+
+jest.mock("../util/metadata", () => ({
+  __esModule: true,
+  getMetaContent: (field: MetaDataKey) => `${field} value`,
+}));
+
+jest.mock("phoenix", () => ({
+  __esModule: true,
+  Socket: jest.fn(),
+}));
+
+const mockSocket = Socket as jest.MockedClass<typeof Socket>;
+
+describe("initSocket", () => {
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+
+  test("loads without issue if everything is valid", () => {
+    const { socket, onOpen, getChannel } = makeMockSocket();
+    mockSocket.mockImplementationOnce(() => socket);
+    initSocket();
+    expect(mockSocket).toHaveBeenCalledWith("/socket", {
+      params: {
+        token: "guardianToken value",
+        release: "release value",
+      },
+    });
+    onOpen();
+    const channel = getChannel("metadata")!;
+    expect(channel.channel.join).toHaveBeenCalled();
+    channel.joinReceive("ok", {
+      authenticated: true,
+      server_release: "release value",
+    });
+    expect(reload).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test("reloads if auth fails", () => {
+    const { socket, onOpen, getChannel } = makeMockSocket();
+    mockSocket.mockImplementationOnce(() => socket);
+    initSocket();
+    onOpen();
+    const channel = getChannel("metadata")!;
+    channel.joinReceive("ok", {
+      authenticated: false,
+      server_release: "release value",
+    });
+    expect(reload).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test("reloads if server version changes", () => {
+    const { socket, onOpen, getChannel } = makeMockSocket();
+    mockSocket.mockImplementationOnce(() => socket);
+    initSocket();
+    onOpen();
+    const channel = getChannel("metadata")!;
+    expect(channel.channel.join).toHaveBeenCalled();
+    channel.joinReceive("ok", {
+      authenticated: true,
+      server_release: "newer release",
+    });
+    expect(reload).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test("doesn't reload if socket doesn't connect", () => {
+    // phoenix will retry the connection but that's not our code so not tested here
+    const { socket, onError } = makeMockSocket();
+    mockSocket.mockImplementationOnce(() => socket);
+    initSocket();
+    onError();
+    expect(reload).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/js/util/metadata.ts
+++ b/js/util/metadata.ts
@@ -1,12 +1,13 @@
 export type MetaDataKey =
   | "appcuesUserId"
   | "csrf-token"
-  | "fullStoryOrgId"
-  | "sentryDsn"
   | "environment"
+  | "fullStoryOrgId"
+  | "guardianToken"
+  | "release"
+  | "sentryDsn"
   | "userEmail"
-  | "userName"
-  | "release";
+  | "userName";
 
 export const getMetaContent = (field: MetaDataKey): string | null => {
   const element = document.querySelector(`meta[name=${field}]`);

--- a/lib/orbit_web/channels/metadata_channel.ex
+++ b/lib/orbit_web/channels/metadata_channel.ex
@@ -1,0 +1,18 @@
+defmodule OrbitWeb.MetadataChannel do
+  @moduledoc """
+  Data that should be returned when connecting to user_socket.ex,
+  except that you phoenix can't reply to a socket connection, so instead
+  clients should join this channel after connecting.
+  """
+  use OrbitWeb, :channel
+
+  @impl true
+  def join("metadata", _payload, socket) do
+    reply = %{
+      server_release: socket.assigns.server_release,
+      authenticated: socket.assigns.authenticated
+    }
+
+    {:ok, reply, socket}
+  end
+end

--- a/lib/orbit_web/channels/user_socket.ex
+++ b/lib/orbit_web/channels/user_socket.ex
@@ -1,0 +1,94 @@
+defmodule OrbitWeb.UserSocket do
+  @moduledoc """
+  Will always allow connection, even if user is unauthenticated or out of date,
+  So that we can tell the client what the issue is and they can handle it (by refreshing).
+
+  If we refuse unauthenticated connections, then the client can't tell the difference between
+  an auth problem where they should log in again, and a network problem where they should reconnect.
+  Phoenix has a way to reply with a connection error, and it reaches the browser, but not in a
+  way that's visible to the frontend application code.
+
+  After connection, clients should connect to the `metadata` channel to learn whether they were
+  authenticated or not.
+
+  All other channels should remember to check the release version and
+  authentication/authorization before allowing a client to join the channel.
+  """
+
+  use Phoenix.Socket
+  require Logger
+
+  channel "metadata", OrbitWeb.MetadataChannel
+
+  @doc """
+  fields that are added to socket.assigns
+  """
+  @type metadata :: %{
+          server_release: String.t(),
+          client_release: String.t() | nil,
+          release_matches: boolean(),
+          authenticated: boolean(),
+          user_id: integer() | nil,
+          email: String.t() | nil,
+          authentication_error: :no_token | :invalid_token | nil
+        }
+
+  @impl true
+  def connect(params, socket, _connect_info) do
+    server_release = Application.fetch_env!(:orbit, :release)
+    client_release = params["release"]
+
+    {socket, user, authentication_error} =
+      case Guardian.Phoenix.Socket.authenticate(socket, OrbitWeb.Auth.Guardian, params["token"]) do
+        {:error, :no_token} ->
+          {socket, nil, :no_token}
+
+        {:error, _e} ->
+          {socket, nil, :invalid_token}
+
+        {:ok, authed_socket} ->
+          user = Guardian.Phoenix.Socket.current_resource(authed_socket)
+          {authed_socket, user, nil}
+      end
+
+    metadata = %{
+      server_release: server_release,
+      client_release: client_release,
+      release_matches: client_release == server_release,
+      authenticated: user != nil,
+      user_id: user && user.id,
+      email: user && user.email,
+      authentication_error: authentication_error
+    }
+
+    metadata_log =
+      metadata
+      |> Enum.map(fn {key, val} -> "#{key}=#{val}" end)
+      |> Enum.join(" ")
+
+    Logger.info("user_socket connected #{metadata_log}")
+
+    {:ok, assign(socket, metadata)}
+  end
+
+  # Socket IDs are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     Elixir.OrbitWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  @impl true
+  def id(socket) do
+    case socket.assigns.user_id do
+      nil ->
+        nil
+
+      id ->
+        "user_socket:#{id}"
+    end
+  end
+end

--- a/lib/orbit_web/channels/user_socket.ex
+++ b/lib/orbit_web/channels/user_socket.ex
@@ -61,11 +61,7 @@ defmodule OrbitWeb.UserSocket do
       authentication_error: authentication_error
     }
 
-    metadata_log =
-      metadata
-      |> Enum.map(fn {key, val} -> "#{key}=#{val}" end)
-      |> Enum.join(" ")
-
+    metadata_log = Enum.map_join(metadata, " ", fn {key, val} -> "#{key}=#{val}" end)
     Logger.info("user_socket connected #{metadata_log}")
 
     {:ok, assign(socket, metadata)}

--- a/lib/orbit_web/components/layouts/root.html.heex
+++ b/lib/orbit_web/components/layouts/root.html.heex
@@ -14,6 +14,9 @@
     <%= if @conn.assigns[:logged_in_user] do %>
       <meta name="email" content={@logged_in_user.email} />
     <% end %>
+    <%= if @conn.assigns[:guardian_token] do %>
+      <meta name="guardianToken" content={@guardian_token} />
+    <% end %>
     <meta name="release" content={@release} />
 
     <%= if @conn.assigns[:sentry_dsn] do %>

--- a/lib/orbit_web/controllers/react_app_controller.ex
+++ b/lib/orbit_web/controllers/react_app_controller.ex
@@ -11,6 +11,7 @@ defmodule OrbitWeb.ReactAppController do
       appcues_uid: appcues_uid(conn),
       environment: Application.get_env(:orbit, :environment),
       full_story_org_id: Application.get_env(:orbit, :full_story_org_id),
+      guardian_token: Guardian.Plug.current_token(conn),
       sentry_dsn: Application.get_env(:sentry, :dsn)
     )
   end

--- a/lib/orbit_web/endpoint.ex
+++ b/lib/orbit_web/endpoint.ex
@@ -16,6 +16,8 @@ defmodule OrbitWeb.Endpoint do
     websocket: [connect_info: [session: @session_options]],
     longpoll: [connect_info: [session: @session_options]]
 
+  socket "/socket", OrbitWeb.UserSocket
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/test/orbit_web/channels/metadata_channel_test.exs
+++ b/test/orbit_web/channels/metadata_channel_test.exs
@@ -24,8 +24,8 @@ defmodule OrbitWeb.MetadataChannelTest do
       assert %{authenticated: false} = reply
     end
 
-    # @authenticated makes a socket for us, but this test ignores it and makes its own socket so we can pass custom params
-    # but we still need the @authenticated tag so we get a user and token set up for us
+    # @tag: authenticated makes a socket for us, but this test makes its own socket so we can pass custom params
+    # but we still need the authenticated tag so we get a user and token set up for us
     @tag :authenticated
     test "replies to out of date release", %{token: token} do
       server_release = Application.fetch_env!(:orbit, :release)

--- a/test/orbit_web/channels/metadata_channel_test.exs
+++ b/test/orbit_web/channels/metadata_channel_test.exs
@@ -1,0 +1,44 @@
+defmodule OrbitWeb.MetadataChannelTest do
+  use OrbitWeb.ChannelCase
+
+  # also tests user_socket.ex connect/3 logic.
+  describe "join" do
+    @tag :authenticated
+    test "replies to healthy authenticated channel", %{socket: socket} do
+      {:ok, reply, _socket} = subscribe_and_join(socket, OrbitWeb.MetadataChannel, "metadata")
+
+      assert reply == %{
+               authenticated: true,
+               server_release: Application.fetch_env!(:orbit, :release)
+             }
+    end
+
+    test "replies to join with invalid token" do
+      {:ok, socket} =
+        Phoenix.ChannelTest.connect(OrbitWeb.UserSocket, %{
+          token: "bad token",
+          release: Application.fetch_env!(:orbit, :release)
+        })
+
+      {:ok, reply, _socket} = subscribe_and_join(socket, OrbitWeb.MetadataChannel, "metadata")
+      assert %{authenticated: false} = reply
+    end
+
+    # @authenticated makes a socket for us, but this test ignores it and makes its own socket so we can pass custom params
+    # but we still need the @authenticated tag so we get a user and token set up for us
+    @tag :authenticated
+    test "replies to out of date release", %{token: token} do
+      server_release = Application.fetch_env!(:orbit, :release)
+      client_release = server_release <> "outdated release"
+
+      {:ok, socket} =
+        Phoenix.ChannelTest.connect(OrbitWeb.UserSocket, %{
+          token: token,
+          release: client_release
+        })
+
+      {:ok, reply, _socket} = subscribe_and_join(socket, OrbitWeb.MetadataChannel, "metadata")
+      assert %{server_release: ^server_release} = reply
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,64 @@
+defmodule OrbitWeb.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  channel tests.
+
+  Such tests rely on `Phoenix.ChannelTest` and also
+  import other functionality to make it easier
+  to build common data structures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use OrbitWeb.ChannelCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  @endpoint OrbitWeb.Endpoint
+
+  use ExUnit.CaseTemplate
+  require Phoenix.ChannelTest
+
+  using do
+    quote do
+      import Phoenix.ChannelTest
+      import OrbitWeb.ChannelCase
+
+      # The default endpoint for testing
+      @endpoint OrbitWeb.Endpoint
+    end
+  end
+
+  setup tags do
+    Orbit.DataCase.setup_sandbox(tags)
+
+    {token, user_id, email} =
+      if tags[:authenticated] do
+        conn =
+          Phoenix.ConnTest.build_conn()
+          |> Plug.Test.init_test_session(%{})
+          |> OrbitWeb.Auth.Auth.login(
+            "user@example.com",
+            30,
+            tags[:groups] || [],
+            "https://localhost/fake/logout"
+          )
+
+        token = Guardian.Plug.current_token(conn)
+        user = OrbitWeb.Auth.Auth.logged_in_user(conn)
+
+        {token, user.id, user.email}
+      else
+        {nil, nil, nil}
+      end
+
+    {:ok, socket} =
+      Phoenix.ChannelTest.connect(OrbitWeb.UserSocket, %{
+        token: token,
+        release: Application.fetch_env!(:orbit, :release)
+      })
+
+    {:ok, socket: socket, token: token, user_id: user_id, email: email}
+  end
+end


### PR DESCRIPTION
Asana Task: [📐 Orbit auto-refresh](https://app.asana.com/0/1200689710863995/1208671637680878/f)

Status: I'm not quite done, but I wanted to get what I have pushed, and I'm ready for reviews.

Things I still need to do:
- [x] Frontend tests
- [x] Check that it works on sandbox (label is applied)
- [ ] One more round of manual testing

Makes a new socket. The server tells the client if they're unauthenticated and need to refresh to re-login, or out of date and need to refresh to get a new version.

Unfortunately you can't give an error reason when rejecting a socket connection, so it has to accept the connection and then send the reply. And also unfortunately, you can't reply to a socket connection, so the client has to join a channel and get the reply to that channel join. (I made a phoenix feature request to allow replies so we wouldn't need those workarounds: [Elixir Forum: Feature request: Reply to socket connect](https://elixirforum.com/t/feature-request-reply-to-socket-connect/68694))

- Tests:
  - `( )` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed