### PR TITLE
feat: set Sentry user context in require_login

### DIFF
--- a/lib/orbit_web/controllers/sign_in_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_controller.ex
@@ -81,6 +81,8 @@ defmodule OrbitWeb.SignInController do
       "radio_number" => radio_number
     } = params
 
+    raise "preston error"
+
     # Override is separate for backward compatibility
     override = params["override"]
     signed_in_at = DateTime.from_unix!(signed_in_at)

--- a/lib/orbit_web/controllers/sign_in_controller.ex
+++ b/lib/orbit_web/controllers/sign_in_controller.ex
@@ -81,8 +81,6 @@ defmodule OrbitWeb.SignInController do
       "radio_number" => radio_number
     } = params
 
-    raise "preston error"
-
     # Override is separate for backward compatibility
     override = params["override"]
     signed_in_at = DateTime.from_unix!(signed_in_at)

--- a/lib/orbit_web/plugs/require_login.ex
+++ b/lib/orbit_web/plugs/require_login.ex
@@ -10,10 +10,9 @@ defmodule OrbitWeb.Plugs.RequireLogin do
   @impl Plug
   def call(conn, _opts) do
     if user = Auth.logged_in_user(conn) do
-      # TODO: Sentry
-      # Sentry.Context.set_user_context(%{
-      #   email: user.email
-      # })
+      Sentry.Context.set_user_context(%{
+        email: user.email
+      })
 
       # TODO: Logger
       # Logger.metadata(remote_ip: nil)


### PR DESCRIPTION
Asana Task: [🛠 Orbit saves user in Sentry metadata](https://app.asana.com/0/1206105669438487/1207620537833332/f)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Include user.email in Sentry metadata so Sentry traces that have passed through the RequireLogin plug will have that attached to it.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
