### PR TITLE
fix: appcues and fullstory csp

### DIFF
--- a/lib/orbit_web/router.ex
+++ b/lib/orbit_web/router.ex
@@ -23,7 +23,7 @@ defmodule OrbitWeb.Router do
         frame-src 'self' https://*.appcues.com;\
         img-src 'self' https://*.appcues.com https://*.appcues.net res.cloudinary.com cdn.jsdelivr.net;\
         script-src 'self' *.fullstory.com https://*.appcues.com https://*.appcues.net;\
-        script-src-elem 'self' 'unsafe-inline';\
+        script-src-elem 'self' *.fullstory.com https://*.appcues.com https://*.appcues.net 'unsafe-inline';\
         style-src 'self' https://*.appcues.com https://*.appcues.net https://fonts.googleapis.com https://fonts.google.com 'unsafe-inline';\
         "
     }


### PR DESCRIPTION
Asana Task: None

Fixes this problem:

<img width="1042" alt="CSP console warnings" src="https://github.com/user-attachments/assets/e928c6a1-1fba-44d9-9c60-09a902e20ddc" />

This problem was introduced in https://github.com/mbta/orbit/pull/218 . I fixed one thing but broke another, cuz the new `script-src-elem` was overriding the `script-src` that was allowing appcues and fullstory.

Deploying to sandbox to test.

- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
