### PR TITLE
fix: vehicle position channel was sending an invalid object on join

### DIFF
--- a/lib/orbit_web/channels/train_locations_channel.ex
+++ b/lib/orbit_web/channels/train_locations_channel.ex
@@ -5,7 +5,7 @@ defmodule OrbitWeb.TrainLocationsChannel do
   @impl true
   def join("train_locations", _payload, socket) do
     current_positions = Realtime.PollingServer.subscribe(self(), :vehicle_positions)
-    {:ok, %{data: Jason.encode!(current_positions)}, socket}
+    {:ok, %{data: current_positions}, socket}
   end
 
   @impl true

--- a/test/orbit_web/channels/train_locations_channel_test.exs
+++ b/test/orbit_web/channels/train_locations_channel_test.exs
@@ -42,6 +42,12 @@ defmodule OrbitWeb.TrainLocationsChannelTest do
 
   describe "TrainLocationsChannel" do
     @tag :authenticated
+    test "channel sends data object to client on join", %{socket: socket} do
+      {:ok, data, _socket} = subscribe_and_join(socket, TrainLocationsChannel, "train_locations")
+      assert %{data: %{timestamp: _, entities: _}} = data
+    end
+
+    @tag :authenticated
     test "channel forwards train locations to client", %{socket: socket} do
       {:ok, _, socket} = subscribe_and_join(socket, TrainLocationsChannel, "train_locations")
 


### PR DESCRIPTION
Asana Task: [Hook up useVehiclePositions to VehiclePosition model](https://app.asana.com/0/1200273269966439/1210103496602886)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

The channel sends vehicle positions in two cases:
a) On channel join
b) On each poll of upstream

[b] was working, while [a] was still sending a JSON-stringified version of the full data. So https://orbit-staging.mbtace.com/ladder displays "Status: Connected", but errors at first. It only works after the next routine poll, making it appear to take 1-3 additional seconds to load.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
