### PR TITLE
feat: render train pill colors based on Ashmont/Braintree

### DIFF
--- a/js/components/ladderPage/ladder.tsx
+++ b/js/components/ladderPage/ladder.tsx
@@ -114,10 +114,13 @@ const TrainsAndStations = ({
         const isAshmontLadder = ladderConfig.some(
           (station) => station.id === "place-asmnl",
         );
+        const isBraintreeLadder = ladderConfig.some(
+          (station) => station.id === "place-brntn",
+        );
         const routePattern =
-          isAshmontLadder ? "Red-Ashmont" : (
-            (trainRoutePatternFromVehicle(vehicle) ?? "Red-Braintree")
-          );
+          isAshmontLadder ? "Red-Ashmont"
+          : isBraintreeLadder ? "Red-Braintree"
+          : (trainRoutePatternFromVehicle(vehicle) ?? "Red-Braintree");
 
         const station = ladderConfig.find((station) =>
           station.stop_ids.some((stop_id) => stop_id === vp.stopId),

--- a/js/components/ladderPage/ladder.tsx
+++ b/js/components/ladderPage/ladder.tsx
@@ -3,6 +3,7 @@ import { useTripUpdates } from "../../hooks/useTripUpdates";
 import { useVehiclePositions } from "../../hooks/useVehiclePositions";
 import { RouteId } from "../../models/common";
 import {
+  trainRoutePatternFromVehicle,
   Vehicle,
   vehiclesFromPositionsAndTripUpdates,
 } from "../../models/vehicle";
@@ -108,11 +109,15 @@ const TrainsAndStations = ({
         // add 80 for top margin above the station list borders
         const px = trainHeight + 80;
 
-        // TODO: this flat-out ignores that Ashmont-bound trains may be on the main ladder
-        const route =
-          ladderConfig.some((station) => station.id === "place-asmnl") ?
-            "Red-Ashmont"
-          : "Red-Braintree";
+        // TODO: Discuss if we actually want to keep the ladder-based logic here, or just always
+        // rely on the pattern name.
+        const isAshmontLadder = ladderConfig.some(
+          (station) => station.id === "place-asmnl",
+        );
+        const routePattern =
+          isAshmontLadder ? "Red-Ashmont" : (
+            (trainRoutePatternFromVehicle(vehicle) ?? "Red-Braintree")
+          );
 
         const station = ladderConfig.find((station) =>
           station.stop_ids.some((stop_id) => stop_id === vp.stopId),
@@ -129,7 +134,11 @@ const TrainsAndStations = ({
             style={{ position: "absolute", top: `${px}px` }}
             className={direction === 0 ? "left-[24px]" : "right-[24px]"}
           >
-            <Train route={route} label={vp.label} direction={direction} />
+            <Train
+              routePattern={routePattern}
+              label={vp.label}
+              direction={direction}
+            />
           </div>
         );
       })}

--- a/js/components/ladderPage/train.tsx
+++ b/js/components/ladderPage/train.tsx
@@ -1,20 +1,22 @@
+import { TrainRoutePattern } from "../../models/trainRoutePattern";
 import { className } from "../../util/dom";
 import { ReactElement } from "react";
 
 export const Train = ({
-  route,
+  routePattern,
   label,
   highlight,
   direction,
   className: extraClassName,
 }: {
-  route: "Red-Ashmont" | "Red-Braintree";
+  routePattern: TrainRoutePattern;
   label: string;
   highlight?: boolean;
   direction: number;
   className?: string;
 }): ReactElement => {
-  const bgColor = route === "Red-Braintree" ? "bg-crimson" : "bg-tangerine";
+  const bgColor =
+    routePattern === "Red-Braintree" ? "bg-crimson" : "bg-tangerine";
   const orientation = direction == 0 ? "right-0" : "left-0";
   return (
     <div className="relative">
@@ -23,9 +25,9 @@ export const Train = ({
         className={className([
           "m-1 relative flex items-center justify-center rounded-3xl w-24 h-10 font-semibold",
           highlight ? "border-[3px] animate-pulse" : "border",
-          route === "Red-Braintree" ? "border-crimson"
+          routePattern === "Red-Braintree" ? "border-crimson"
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          : route === "Red-Ashmont" ? "border-tangerine"
+          : routePattern === "Red-Ashmont" ? "border-tangerine"
           : "",
           extraClassName,
         ])}
@@ -47,7 +49,9 @@ export const Train = ({
         <div
           className={className([
             "absolute rounded-full h-[32px] w-[32px] border-8 border-opacity-35",
-            route == "Red-Braintree" ? "border-crimson" : "border-tangerine",
+            routePattern == "Red-Braintree" ? "border-crimson" : (
+              "border-tangerine"
+            ),
             direction == 0 ?
               highlight ? "translate-x-[calc(100%+10px)]"
               : "translate-x-[calc(100%+8px)]"

--- a/js/models/trainRoutePattern.ts
+++ b/js/models/trainRoutePattern.ts
@@ -1,0 +1,17 @@
+// Represents a hard-coded list of understood route patterns
+export type TrainRoutePattern = "Red-Ashmont" | "Red-Braintree";
+
+// We assume that the set of route patterns we care about can be mapped from
+// a known set of IDs.
+const patternIdsToNames: Record<string, TrainRoutePattern | undefined> = {
+  "Red-1-0": "Red-Ashmont",
+  "Red-1-1": "Red-Ashmont",
+  "Red-3-0": "Red-Braintree",
+  "Red-3-1": "Red-Braintree",
+};
+
+export const trainRoutePatternFromId = (
+  routePatternId: string,
+): TrainRoutePattern | undefined => {
+  return patternIdsToNames[routePatternId];
+};

--- a/js/models/tripDescriptor.ts
+++ b/js/models/tripDescriptor.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export type TripDescriptor = {
+  tripId?: string | null;
+  // Note: The spec includes additional fields that can be used to identify a trip
+  // but for now we will only concern ourselves with trip ID
+};
+
+export const TripDescriptor = z.object({
+  tripId: z.string().nullable().optional(),
+}) satisfies z.ZodType<TripDescriptor>;
+
+export const TripDescriptorData = z.object({
+  trip_id: z.string().nullable().optional(),
+});
+export type TripDescriptorData = z.infer<typeof TripDescriptorData>;
+
+export const tripDescriptorFromData = (
+  data: TripDescriptorData,
+): TripDescriptor => ({
+  tripId: data.trip_id,
+});

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -14,6 +14,7 @@ export type TripUpdate = {
   label: string | null;
   routeId: RouteId;
   direction: number;
+  // TODO: Verify nullability of this field.
   routePatternId: string | null;
   tripId: string;
   vehicleId: string;

--- a/js/models/vehicle.ts
+++ b/js/models/vehicle.ts
@@ -1,3 +1,7 @@
+import {
+  TrainRoutePattern,
+  trainRoutePatternFromId,
+} from "./trainRoutePattern";
 import { TripUpdate } from "./tripUpdate";
 import { VehiclePosition } from "./vehiclePosition";
 
@@ -28,4 +32,13 @@ export const vehiclesFromPositionsAndTripUpdates = (
       ...(tripUpdate ? { tripUpdate } : {}),
     };
   });
+};
+
+export const trainRoutePatternFromVehicle = (
+  vehicle: Vehicle,
+): TrainRoutePattern | undefined => {
+  const routePatternId = vehicle.tripUpdate?.routePatternId;
+  if (routePatternId) {
+    return trainRoutePatternFromId(routePatternId);
+  }
 };

--- a/js/models/vehicle.ts
+++ b/js/models/vehicle.ts
@@ -1,0 +1,31 @@
+import { TripUpdate } from "./tripUpdate";
+import { VehiclePosition } from "./vehiclePosition";
+
+export type Vehicle = {
+  vehiclePosition: VehiclePosition;
+  tripUpdate?: TripUpdate;
+};
+
+export const vehiclesFromPositionsAndTripUpdates = (
+  vehiclePositions: VehiclePosition[],
+  tripUpdates: TripUpdate[],
+): Vehicle[] => {
+  const tripUpdateById = new Map<string, TripUpdate>();
+  for (const tripUpdate of tripUpdates) {
+    const existing = tripUpdateById.get(tripUpdate.tripId);
+    if (existing) {
+      console.error("Multiple updates for trip. Overwriting");
+      console.error(existing);
+    }
+    tripUpdateById.set(tripUpdate.tripId, tripUpdate);
+  }
+
+  return vehiclePositions.map((vehiclePosition) => {
+    const tripId = vehiclePosition.trip?.tripId;
+    const tripUpdate = tripId && tripUpdateById.get(tripId);
+    return {
+      vehiclePosition,
+      ...(tripUpdate ? { tripUpdate } : {}),
+    };
+  });
+};

--- a/js/models/vehiclePosition.ts
+++ b/js/models/vehiclePosition.ts
@@ -1,6 +1,11 @@
 import { dateTimeFromISO } from "../dateTime";
 import { CarId, DirectionId, RouteId, StationId } from "./common";
 import { LatLng } from "./latlng";
+import {
+  TripDescriptor,
+  TripDescriptorData,
+  tripDescriptorFromData,
+} from "./tripDescriptor";
 import { DateTime } from "luxon";
 import { z } from "zod";
 
@@ -36,6 +41,7 @@ export const VehiclePositionData = z.object({
   current_status: StopStatusData,
   timestamp: z.string().nullable(),
   vehicle_id: z.string().nullable(),
+  trip: TripDescriptorData,
 });
 export type VehiclePositionData = z.infer<typeof VehiclePositionData>;
 
@@ -59,7 +65,7 @@ export type VehiclePosition = {
   heading: number | null;
   timestamp: DateTime | null;
   vehicleId: string | null;
-  // trip: TripEnd | null;
+  trip: TripDescriptor | null;
 };
 
 export const vehiclePositionFromData = (
@@ -76,5 +82,5 @@ export const vehiclePositionFromData = (
   heading: data.heading,
   timestamp: data.timestamp !== null ? dateTimeFromISO(data.timestamp) : null,
   vehicleId: data.vehicle_id,
-  // trip: data.trip !== null ? tripEndFromData(data.trip) : null,
+  trip: tripDescriptorFromData(data.trip),
 });

--- a/js/test/components/ladderPage/ladder.test.tsx
+++ b/js/test/components/ladderPage/ladder.test.tsx
@@ -1,7 +1,11 @@
 import { Ladders } from "../../../components/ladderPage/ladder";
+import { useTripUpdates } from "../../../hooks/useTripUpdates";
 import { useVehiclePositions } from "../../../hooks/useVehiclePositions";
 import { StopStatus } from "../../../models/vehiclePosition";
-import { vehiclePositionFactory } from "../../helpers/factory";
+import {
+  tripUpdateFactory,
+  vehiclePositionFactory,
+} from "../../helpers/factory";
 import { render } from "@testing-library/react";
 
 jest.mock("../../../hooks/useVehiclePositions", () => ({
@@ -12,9 +16,18 @@ const mockUseVehiclePositions = useVehiclePositions as jest.MockedFunction<
   typeof useVehiclePositions
 >;
 
+jest.mock("../../../hooks/useTripUpdates", () => ({
+  __esModule: true,
+  useTripUpdates: jest.fn(),
+}));
+const mockUseTripUpdates = useTripUpdates as jest.MockedFunction<
+  typeof useTripUpdates
+>;
+
 describe("Ladder", () => {
   test("shows station names", () => {
     mockUseVehiclePositions.mockReturnValue([]);
+    mockUseTripUpdates.mockReturnValue([]);
     const view = render(<Ladders routeId={"Red"} />);
     expect(view.getByText("Alewife")).toBeInTheDocument();
     expect(view.getByText("Ashmont")).toBeInTheDocument();
@@ -44,10 +57,102 @@ describe("Ladder", () => {
         stopId: null,
       }),
     ]);
+    mockUseTripUpdates.mockReturnValue([]);
+
     const view = render(<Ladders routeId="Red" />);
     expect(view.getByText("1877")).toBeInTheDocument();
     expect(view.getByText("1888")).toBeInTheDocument();
     expect(view.getByText("1889")).toBeInTheDocument();
     expect(view.queryByText("1999")).not.toBeInTheDocument();
+  });
+
+  describe("pill colors", () => {
+    beforeEach(() => {
+      mockUseTripUpdates.mockReturnValue([
+        tripUpdateFactory.build({
+          tripId: "11111",
+          routePatternId: "Red-1-0",
+        }),
+        tripUpdateFactory.build({
+          tripId: "22222",
+          routePatternId: "Red-3-0",
+        }),
+      ]);
+    });
+
+    describe("when trains are on alewife branch of ladder", () => {
+      test("renders pill color based on route pattern", () => {
+        mockUseVehiclePositions.mockReturnValue([
+          vehiclePositionFactory.build({
+            label: "1888",
+            stationId: "place-davis",
+            stopId: "70064",
+            trip: { tripId: "11111" },
+          }),
+          vehiclePositionFactory.build({
+            label: "1889",
+            stationId: "place-davis",
+            stopId: "70064",
+            trip: { tripId: "22222" },
+          }),
+        ]);
+
+        const view = render(<Ladders routeId="Red" />);
+        expect(view.getByText("1888")).toBeInTheDocument();
+        expect(view.getByText("1888")).toHaveClass("border-tangerine");
+        expect(view.getByText("1889")).toBeInTheDocument();
+        expect(view.getByText("1889")).toHaveClass("border-crimson");
+      });
+    });
+
+    describe("when trains are on ashmont branch of ladder", () => {
+      test("renders orange pill color regardless of route pattern", () => {
+        mockUseVehiclePositions.mockReturnValue([
+          vehiclePositionFactory.build({
+            label: "1888",
+            stationId: "place-jfk",
+            stopId: "70085",
+            trip: { tripId: "11111" },
+          }),
+          vehiclePositionFactory.build({
+            label: "1889",
+            stationId: "place-jfk",
+            stopId: "70086",
+            trip: { tripId: "22222" },
+          }),
+        ]);
+
+        const view = render(<Ladders routeId="Red" />);
+        expect(view.getByText("1888")).toBeInTheDocument();
+        expect(view.getByText("1888")).toHaveClass("border-tangerine");
+        expect(view.getByText("1889")).toBeInTheDocument();
+        expect(view.getByText("1889")).toHaveClass("border-tangerine");
+      });
+    });
+
+    describe("when trains are on braintree branch of ladder", () => {
+      test("renders red pill color regardless of route pattern", () => {
+        mockUseVehiclePositions.mockReturnValue([
+          vehiclePositionFactory.build({
+            label: "1888",
+            stationId: "place-jfk",
+            stopId: "70095",
+            trip: { tripId: "11111" },
+          }),
+          vehiclePositionFactory.build({
+            label: "1889",
+            stationId: "place-jfk",
+            stopId: "70096",
+            trip: { tripId: "22222" },
+          }),
+        ]);
+
+        const view = render(<Ladders routeId="Red" />);
+        expect(view.getByText("1888")).toBeInTheDocument();
+        expect(view.getByText("1888")).toHaveClass("border-crimson");
+        expect(view.getByText("1889")).toBeInTheDocument();
+        expect(view.getByText("1889")).toHaveClass("border-crimson");
+      });
+    });
   });
 });

--- a/js/test/components/ladderPage/train.test.tsx
+++ b/js/test/components/ladderPage/train.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@testing-library/react";
 describe("Train", () => {
   test("shows label", () => {
     const view = render(
-      <Train route="Red-Ashmont" label="1875" direction={0} />,
+      <Train routePattern="Red-Ashmont" label="1875" direction={0} />,
     );
     expect(view.getByText("1875")).toBeInTheDocument();
   });
@@ -12,7 +12,7 @@ describe("Train", () => {
   test("accepts additional properties", () => {
     const view = render(
       <Train
-        route="Red-Ashmont"
+        routePattern="Red-Ashmont"
         label="1875"
         highlight={true}
         direction={0}

--- a/js/test/helpers/factory.ts
+++ b/js/test/helpers/factory.ts
@@ -2,6 +2,7 @@ import { dateTimeFromISO } from "../../dateTime";
 import { Certification, CertificationData } from "../../models/certification";
 import { Employee } from "../../models/employee";
 import { StopTimeUpdate, TripUpdate } from "../../models/tripUpdate";
+import { Vehicle } from "../../models/vehicle";
 import { StopStatus, VehiclePosition } from "../../models/vehiclePosition";
 import { Factory } from "fishery";
 import { DateTime } from "luxon";
@@ -55,4 +56,9 @@ export const tripUpdateFactory = Factory.define<TripUpdate>(() => ({
   tripId: "68078228",
   vehicleId: "R-54831F04",
   stopTimeUpdates: [stopTimeUpdateFactory.build()],
+}));
+
+export const vehicleFactory = Factory.define<Vehicle>(() => ({
+  vehiclePosition: vehiclePositionFactory.build(),
+  tripUpdate: tripUpdateFactory.build(),
 }));

--- a/js/test/helpers/factory.ts
+++ b/js/test/helpers/factory.ts
@@ -37,6 +37,7 @@ export const vehiclePositionFactory = Factory.define<VehiclePosition>(() => ({
   stopStatus: StopStatus.InTransitTo,
   timestamp: dateTimeFromISO("2025-04-29T21:27:26.679Z"),
   vehicleId: "R-5482CAAA",
+  trip: { tripId: "68077971" },
 }));
 
 export const stopTimeUpdateFactory = Factory.define<StopTimeUpdate>(() => ({

--- a/js/test/models/trainRoutePattern.test.ts
+++ b/js/test/models/trainRoutePattern.test.ts
@@ -1,0 +1,17 @@
+import { trainRoutePatternFromId } from "../../models/trainRoutePattern";
+
+describe("trainRoutePatternFromId", () => {
+  test("derives Red-Ashmont patterns from expected pattern IDs", () => {
+    expect(trainRoutePatternFromId("Red-1-0")).toBe("Red-Ashmont");
+    expect(trainRoutePatternFromId("Red-1-1")).toBe("Red-Ashmont");
+  });
+
+  test("derives Red-Braintree patterns from expected pattern IDs", () => {
+    expect(trainRoutePatternFromId("Red-3-0")).toBe("Red-Braintree");
+    expect(trainRoutePatternFromId("Red-3-1")).toBe("Red-Braintree");
+  });
+
+  test("returns undefined if pattern ID matches no expected route pattern", () => {
+    expect(trainRoutePatternFromId("Some-Other-Pattern")).toBeUndefined();
+  });
+});

--- a/js/test/models/vehicle.test.ts
+++ b/js/test/models/vehicle.test.ts
@@ -1,5 +1,15 @@
-import { vehiclesFromPositionsAndTripUpdates } from "../../models/vehicle";
-import { tripUpdateFactory, vehiclePositionFactory } from "../helpers/factory";
+import { trainRoutePatternFromId } from "../../models/trainRoutePattern";
+import {
+  trainRoutePatternFromVehicle,
+  vehiclesFromPositionsAndTripUpdates,
+} from "../../models/vehicle";
+import {
+  tripUpdateFactory,
+  vehicleFactory,
+  vehiclePositionFactory,
+} from "../helpers/factory";
+
+jest.mock("../../models/trainRoutePattern");
 
 describe("vehiclesFromPositionsAndTripUpdates", () => {
   test("matches vehicle positions and trip updates", () => {
@@ -54,5 +64,31 @@ describe("vehiclesFromPositionsAndTripUpdates", () => {
     expect(v1890?.tripUpdate).toBeUndefined();
     expect(v1891).toBeDefined();
     expect(v1891?.tripUpdate).toBeUndefined();
+  });
+});
+
+describe("trainRoutePatternFromVehicle", () => {
+  test("derives route patterns from trip update route_pattern_id", () => {
+    jest.mocked(trainRoutePatternFromId).mockReturnValue("Red-Ashmont");
+    const vehicle = vehicleFactory.build({
+      tripUpdate: tripUpdateFactory.build({
+        routePatternId: "Red-1-0",
+      }),
+    });
+    expect(trainRoutePatternFromVehicle(vehicle)).toBe("Red-Ashmont");
+    expect(trainRoutePatternFromId).toHaveBeenCalledWith("Red-1-0");
+  });
+
+  test("returns undefined if tripUpdate or pattern ID is missing", () => {
+    const vehicle1 = vehicleFactory.build({
+      tripUpdate: tripUpdateFactory.build({
+        routePatternId: null,
+      }),
+    });
+    const vehicle2 = vehicleFactory.build({
+      tripUpdate: undefined,
+    });
+    expect(trainRoutePatternFromVehicle(vehicle1)).toBeUndefined();
+    expect(trainRoutePatternFromVehicle(vehicle2)).toBeUndefined();
   });
 });

--- a/js/test/models/vehicle.test.ts
+++ b/js/test/models/vehicle.test.ts
@@ -1,0 +1,58 @@
+import { vehiclesFromPositionsAndTripUpdates } from "../../models/vehicle";
+import { tripUpdateFactory, vehiclePositionFactory } from "../helpers/factory";
+
+describe("vehiclesFromPositionsAndTripUpdates", () => {
+  test("matches vehicle positions and trip updates", () => {
+    const vehiclePositions = [
+      vehiclePositionFactory.build({
+        label: "1888",
+        trip: { tripId: "11111" },
+      }),
+      vehiclePositionFactory.build({
+        label: "1889",
+        trip: { tripId: "22222" },
+      }),
+      vehiclePositionFactory.build({
+        label: "1890",
+        trip: { tripId: "33333" },
+      }),
+      vehiclePositionFactory.build({
+        label: "1891",
+        trip: null,
+      }),
+    ];
+
+    const tripUpdates = [
+      tripUpdateFactory.build({
+        tripId: "11111",
+      }),
+      tripUpdateFactory.build({
+        tripId: "22222",
+      }),
+    ];
+
+    const vehicles = vehiclesFromPositionsAndTripUpdates(
+      vehiclePositions,
+      tripUpdates,
+    );
+    const v1888 = vehicles.find(
+      (vehicle) => vehicle.vehiclePosition.label === "1888",
+    );
+    const v1889 = vehicles.find(
+      (vehicle) => vehicle.vehiclePosition.label === "1889",
+    );
+    const v1890 = vehicles.find(
+      (vehicle) => vehicle.vehiclePosition.label === "1890",
+    );
+    const v1891 = vehicles.find(
+      (vehicle) => vehicle.vehiclePosition.label === "1891",
+    );
+
+    expect(v1888?.tripUpdate?.tripId).toBe("11111");
+    expect(v1889?.tripUpdate?.tripId).toBe("22222");
+    expect(v1890).toBeDefined();
+    expect(v1890?.tripUpdate).toBeUndefined();
+    expect(v1891).toBeDefined();
+    expect(v1891?.tripUpdate).toBeUndefined();
+  });
+});

--- a/js/test/models/vehiclePosition.test.ts
+++ b/js/test/models/vehiclePosition.test.ts
@@ -27,6 +27,7 @@ describe("vehiclePositionFromData", () => {
         current_status: "INCOMING_AT",
         timestamp: "2025-04-29T20:39:49Z",
         vehicle_id: "R-5482AC4E",
+        trip: { trip_id: "68077971" },
       }),
     ).toEqual({
       routeId: "Red",
@@ -40,6 +41,7 @@ describe("vehiclePositionFromData", () => {
       stopStatus: StopStatus.InTransitTo,
       timestamp: dateTimeFromISO("2025-04-29T20:39:49Z"),
       vehicleId: "R-5482AC4E",
+      trip: { tripId: "68077971" },
     });
   });
 
@@ -57,6 +59,7 @@ describe("vehiclePositionFromData", () => {
         current_status: "STOPPED_AT",
         timestamp: "2025-04-29T20:39:49Z",
         vehicle_id: "R-5482AC4E",
+        trip: { trip_id: "68077971" },
       }),
     ).toEqual({
       routeId: "Red",
@@ -70,6 +73,7 @@ describe("vehiclePositionFromData", () => {
       stopStatus: StopStatus.StoppedAt,
       timestamp: dateTimeFromISO("2025-04-29T20:39:49Z"),
       vehicleId: "R-5482AC4E",
+      trip: { tripId: "68077971" },
     });
   });
 });

--- a/lib/realtime/data/trip_descriptor.ex
+++ b/lib/realtime/data/trip_descriptor.ex
@@ -1,0 +1,54 @@
+defmodule Realtime.Data.TripDescriptor do
+  @moduledoc """
+  A subset of the TripDescriptor type, which contains fields used to specify a unique
+  trip, which may include a trip_id.
+
+  See https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor.
+
+  The spec explains that a trip_id is not always provided, and in that case there are
+  other required criteria for identifying a trip. But for now we will only concern
+  ourselves with trip_id.
+  """
+  @type t :: %__MODULE__{
+          trip_id: String
+        }
+  @derive {Jason.Encoder,
+           only: [
+             :trip_id
+           ]}
+
+  defstruct [
+    :trip_id
+  ]
+end
+
+defmodule Realtime.Data.TripDescriptorType do
+  alias Realtime.Data.TripDescriptor
+
+  use Ecto.Type
+  def type, do: :map
+
+  def cast(%{trip_id: trip_id}) do
+    {:ok, %TripDescriptor{trip_id: trip_id}}
+  end
+
+  def cast(%TripDescriptor{} = position) do
+    {:ok, position}
+  end
+
+  def cast(_), do: :error
+
+  def load(%{trip_id: trip_id}) do
+    {:ok, %TripDescriptor{trip_id: trip_id}}
+  end
+
+  def load(%{"trip_id" => trip_id}) do
+    {:ok, %TripDescriptor{trip_id: trip_id}}
+  end
+
+  def dump(%TripDescriptor{trip_id: trip_id}) do
+    {:ok, %{trip_id: trip_id}}
+  end
+
+  def dump(_), do: :error
+end

--- a/lib/realtime/data/vehicle_position.ex
+++ b/lib/realtime/data/vehicle_position.ex
@@ -17,7 +17,7 @@ defmodule Realtime.Data.VehiclePosition do
           timestamp: DateTime.t(),
           # GTFS-RT id, e.g. "R-54826B16".
           vehicle_id: String.t() | nil,
-          trip: nil
+          trip: Realtime.Data.TripDescriptor.t()
         }
 
   @derive {Jason.Encoder,
@@ -47,7 +47,7 @@ defmodule Realtime.Data.VehiclePosition do
     field(:current_status, Util.AtomType, default: :IN_TRANSIT_TO)
     field(:timestamp, :utc_datetime)
     field(:vehicle_id, :string, virtual: true, default: nil)
-    field(:trip, :map, virtual: true, default: nil)
+    field(:trip, Realtime.Data.TripDescriptorType, default: nil)
     timestamps()
   end
 end

--- a/lib/realtime/rtr.ex
+++ b/lib/realtime/rtr.ex
@@ -3,6 +3,7 @@ defmodule Realtime.RTR do
   for parsing data out of RTR's json feeds
   """
 
+  alias Realtime.Data.TripDescriptor
   alias Realtime.Data.TripUpdate
   alias Realtime.Data.VehiclePosition
   alias Realtime.PollingServer
@@ -40,8 +41,7 @@ defmodule Realtime.RTR do
       current_status: parse_current_status(vehicle["current_status"]),
       timestamp: DateTime.from_unix!(vehicle["timestamp"]),
       vehicle_id: vehicle["vehicle"]["id"],
-      # attached later
-      trip: nil
+      trip: parse_trip_descriptor(vehicle["trip"])
     }
   end
 
@@ -103,4 +103,9 @@ defmodule Realtime.RTR do
   defp parse_current_status("INCOMING_AT"), do: :INCOMING_AT
   defp parse_current_status("STOPPED_AT"), do: :STOPPED_AT
   defp parse_current_status("IN_TRANSIT_TO"), do: :IN_TRANSIT_TO
+
+  @spec parse_trip_descriptor(map() | nil) :: TripDescriptor.t() | nil
+  defp parse_trip_descriptor(%{"trip_id" => trip_id}) do
+    %TripDescriptor{trip_id: trip_id}
+  end
 end

--- a/test/realtime/rtr_test.exs
+++ b/test/realtime/rtr_test.exs
@@ -27,7 +27,8 @@ defmodule Realtime.RTRTest do
                  stop_id: "70071",
                  current_status: :INCOMING_AT,
                  timestamp: ~U[2025-04-23 16:06:35Z],
-                 vehicle_id: "R-5482A2DC"
+                 vehicle_id: "R-5482A2DC",
+                 trip: %Realtime.Data.TripDescriptor{trip_id: "67994935"}
                }
              ]
     end


### PR DESCRIPTION
Asana Task: [Ladder pill colors based on Ashmont/Braintree](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210239106758138?focus=true)

Displays correct colors for train pills on the ladder, with Ashmont trains shown in orange, and Braintree trains shown in red. This determination is made based on the `route_pattern_id` of the vehicle's current `TripUpdate`.

Note that the AC on the ticket says to apply these colors "regardless of ladder", but there was past discussion about whether there could be cases where "Ashmont" trains (based on route pattern) are briefly on the Braintree ladder, or vice versa. So for now I've left in the ladder-based logic and am only using the pattern ID for the Alewife branch. (I'll call this out in the code).

![Screenshot 2025-05-30 at 12 00 46 PM](https://github.com/user-attachments/assets/0fc9c6b3-030c-47d6-afcc-9b4a3d36be5d)

Couple other points of discussion:

- Amended the backend data model for `VehiclePosition` with the minimum change needed to forward the trip descriptor (ie, thing that contains the trip ID). Then matching the vehicle position with trip updates is done on the frontend. Preston and I had talked about alternatively doing that work on the backend (maybe using ecto to store an actual relationship between the two?). I'm still open to that but wanted to get this smaller change up first.

- I created a frontend-only `Vehicle` model, which represents a vehicle position that has (potentially) been matched with a trip update. I refactored ladder and train views to use this new model. Definitely open to feedback on the details here. (I am also considering defining a `useVehicles` hook that does the matching outside of the ladder component.)

- I need to touch base with transit data team to double check that we're not abusing the data in ways that will break, and also to verify little details, like double checking nullability / presence / absence of the trip ID. For example, the docs on the vehicle position's [TripDescriptor](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor) explain that trip ID is not guaranteed. Depending on whether that actually happens for orbit trips, we may need to follow up with some other way of matching vehicles to trip updates.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
