### PR TITLE
fix(trip_updates): handle null fields in trip_update parsing

### DIFF
--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -16,8 +16,8 @@ export type TripUpdate = {
   direction: number | null;
   routePatternId: string | null;
   tripId: string;
-  vehicleId: string;
-  timestamp: DateTime;
+  vehicleId: string | null;
+  timestamp: DateTime | null;
   stopTimeUpdates: StopTimeUpdate[];
 };
 
@@ -48,7 +48,7 @@ export const tripUpdateFromData = (data: TripUpdateData): TripUpdate => ({
   routePatternId: data.route_pattern_id ?? null,
   tripId: data.trip_id,
   vehicleId: data.vehicle_id,
-  timestamp: dateTimeFromUnix(data.timestamp),
+  timestamp: data.timestamp ? dateTimeFromUnix(data.timestamp) : null,
   stopTimeUpdates: data.stop_time_updates.map(stopTimeUpdateFromData),
 });
 
@@ -58,8 +58,8 @@ export const TripUpdateData = z.object({
   direction: z.number().nullable(),
   route_pattern_id: z.string().nullable(),
   trip_id: z.string(),
-  vehicle_id: z.string(),
-  timestamp: z.number(),
+  vehicle_id: z.string().nullable(),
+  timestamp: z.number().nullable(),
   stop_time_updates: z.array(StopTimeUpdateData),
 });
 export type TripUpdateData = z.infer<typeof TripUpdateData>;

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -13,7 +13,7 @@ export type StopTimeUpdateData = z.infer<typeof StopTimeUpdateData>;
 export type TripUpdate = {
   label: string | null;
   routeId: RouteId;
-  direction: number;
+  direction: number | null;
   routePatternId: string | null;
   tripId: string;
   vehicleId: string;
@@ -55,7 +55,7 @@ export const tripUpdateFromData = (data: TripUpdateData): TripUpdate => ({
 export const TripUpdateData = z.object({
   label: z.string().nullable(),
   route_id: z.string(),
-  direction: z.number(),
+  direction: z.number().nullable(),
   route_pattern_id: z.string().nullable(),
   trip_id: z.string(),
   vehicle_id: z.string(),

--- a/lib/realtime/data/trip_update.ex
+++ b/lib/realtime/data/trip_update.ex
@@ -6,7 +6,7 @@ defmodule Realtime.Data.TripUpdate do
   @type t :: %__MODULE__{
           label: String.t() | nil,
           route_id: Realtime.Data.route_id(),
-          direction: String.t(),
+          direction: String.t() | nil,
           route_pattern_id: String.t(),
           trip_id: String.t(),
           vehicle_id: String.t(),

--- a/lib/realtime/data/trip_update.ex
+++ b/lib/realtime/data/trip_update.ex
@@ -9,8 +9,8 @@ defmodule Realtime.Data.TripUpdate do
           direction: String.t() | nil,
           route_pattern_id: String.t(),
           trip_id: String.t(),
-          vehicle_id: String.t(),
-          timestamp: DateTime.t(),
+          vehicle_id: String.t() | nil,
+          timestamp: DateTime.t() | nil,
           stop_time_updates: []
         }
 


### PR DESCRIPTION
Asana Task: [Crash due to non-nullable TripUpdates fields](https://app.asana.com/1/15492006741476/project/1200882337457260/task/1210526410605224?focus=true)

This is a quick fix for the null direction crash. I haven't fully sifted through the trip updates JSON and the GTFS spec, but it looks like there are cases where `direction_id` is not provided, and the orbit backend ends up mapping that into a value of `direction: nil`. The orbit frontend expects this to be non-null, and so zod crashes during parsing.

Whether these values should be allowed in the long term is a bigger question, but right now we're not using them, so I think it's worth merging this in the short-term.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `( )` Doesn't need tests
  - `(X)` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
