### PR TITLE
feat(ocs): add ocs_trips and ocs_trains tables

### DIFF
--- a/lib/orbit/ocs/train.ex
+++ b/lib/orbit/ocs/train.ex
@@ -8,8 +8,9 @@ defmodule Orbit.Ocs.Train do
           service_date: Date.t(),
           uid: String.t(),
           rail_line: RailLine.t(),
-          cars: [String.t()] | nil,
           tags: [String.t()] | nil,
+          cars: [String.t()] | nil,
+          car_tags: [String.t()] | nil,
           deleted: boolean() | nil
         }
   schema "ocs_trains" do
@@ -17,8 +18,9 @@ defmodule Orbit.Ocs.Train do
     field(:uid, :string)
     field(:rail_line, RailLine)
 
-    field(:cars, {:array, :string})
     field(:tags, {:array, :string})
+    field(:cars, {:array, :string})
+    field(:car_tags, {:array, :string})
     field(:deleted, :boolean)
 
     timestamps()
@@ -32,8 +34,9 @@ defmodule Orbit.Ocs.Train do
         :service_date,
         :uid,
         :rail_line,
-        :cars,
         :tags,
+        :cars,
+        :car_tags,
         :deleted
       ]
     )

--- a/lib/orbit/ocs/train.ex
+++ b/lib/orbit/ocs/train.ex
@@ -1,0 +1,47 @@
+defmodule Orbit.Ocs.Train do
+  use Ecto.Schema
+  alias Orbit.RailLine
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          service_date: Date.t(),
+          uid: String.t(),
+          rail_line: RailLine.t(),
+          cars: [String.t()] | nil,
+          tags: [String.t()] | nil,
+          deleted: boolean() | nil
+        }
+  schema "ocs_trains" do
+    field(:service_date, :date)
+    field(:uid, :string)
+    field(:rail_line, RailLine)
+
+    field(:cars, {:array, :string})
+    field(:tags, {:array, :string})
+    field(:deleted, :boolean)
+
+    timestamps()
+  end
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(
+      attrs,
+      [
+        :service_date,
+        :uid,
+        :rail_line,
+        :cars,
+        :tags,
+        :deleted
+      ]
+    )
+    |> unique_constraint([:service_date, :uid, :rail_line])
+    |> validate_required([
+      :service_date,
+      :uid,
+      :rail_line
+    ])
+  end
+end

--- a/lib/orbit/ocs/trip.ex
+++ b/lib/orbit/ocs/trip.ex
@@ -15,6 +15,7 @@ defmodule Orbit.Ocs.Trip do
           trip_type: String.t() | nil,
           scheduled_departure: DateTime.t() | nil,
           scheduled_arrival: DateTime.t() | nil,
+          offset: integer() | nil,
           origin_station: String.t() | nil,
           destination_station: String.t() | nil,
           deleted: boolean() | nil
@@ -34,6 +35,7 @@ defmodule Orbit.Ocs.Trip do
 
     field(:scheduled_departure, :utc_datetime)
     field(:scheduled_arrival, :utc_datetime)
+    field(:offset, :integer)
     field(:origin_station, :string)
     field(:destination_station, :string)
     field(:deleted, :boolean)
@@ -56,6 +58,7 @@ defmodule Orbit.Ocs.Trip do
         :trip_type,
         :scheduled_departure,
         :scheduled_arrival,
+        :offset,
         :origin_station,
         :destination_station,
         :deleted

--- a/lib/orbit/ocs/trip.ex
+++ b/lib/orbit/ocs/trip.ex
@@ -1,0 +1,71 @@
+defmodule Orbit.Ocs.Trip do
+  use Ecto.Schema
+  alias Orbit.RailLine
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          service_date: Date.t(),
+          uid: String.t(),
+          train_uid: String.t() | nil,
+          prev_uid: String.t() | nil,
+          next_uid: String.t() | nil,
+          route: String.t() | nil,
+          rail_line: RailLine.t(),
+          trip_type: String.t() | nil,
+          scheduled_departure: DateTime.t() | nil,
+          scheduled_arrival: DateTime.t() | nil,
+          origin_station: String.t() | nil,
+          destination_station: String.t() | nil,
+          deleted: boolean() | nil
+        }
+
+  schema "ocs_trips" do
+    field(:service_date, :date)
+    field(:uid, :string)
+    field(:train_uid, :string)
+
+    field(:prev_uid, :string)
+    field(:next_uid, :string)
+
+    field(:route, :string)
+    field(:rail_line, RailLine)
+    field(:trip_type, :string)
+
+    field(:scheduled_departure, :utc_datetime)
+    field(:scheduled_arrival, :utc_datetime)
+    field(:origin_station, :string)
+    field(:destination_station, :string)
+    field(:deleted, :boolean)
+
+    timestamps()
+  end
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(
+      attrs,
+      [
+        :service_date,
+        :uid,
+        :train_uid,
+        :prev_uid,
+        :next_uid,
+        :route,
+        :rail_line,
+        :trip_type,
+        :scheduled_departure,
+        :scheduled_arrival,
+        :origin_station,
+        :destination_station,
+        :deleted
+      ]
+    )
+    |> unique_constraint([:service_date, :uid, :rail_line])
+    |> validate_required([
+      :service_date,
+      :uid,
+      :rail_line
+    ])
+  end
+end

--- a/priv/repo/migrations/20250617182608_ocs.exs
+++ b/priv/repo/migrations/20250617182608_ocs.exs
@@ -1,4 +1,4 @@
-defmodule Orbit.Repo.Migrations.OCSTripsTable do
+defmodule Orbit.Repo.Migrations.OCSTables do
   use Ecto.Migration
 
   def change do

--- a/priv/repo/migrations/20250617182608_ocs.exs
+++ b/priv/repo/migrations/20250617182608_ocs.exs
@@ -22,7 +22,7 @@ defmodule Orbit.Repo.Migrations.OCSTables do
     end
 
     create unique_index(:ocs_trips, [:service_date, :uid, :rail_line])
-    create index(:ocs_trips, [:service_date, :train_uid])
+    create index(:ocs_trips, [:service_date, :rail_line, :train_uid])
 
     create table(:ocs_trains) do
       add(:service_date, :date, null: false)

--- a/priv/repo/migrations/20250617182608_ocs.exs
+++ b/priv/repo/migrations/20250617182608_ocs.exs
@@ -28,8 +28,9 @@ defmodule Orbit.Repo.Migrations.OCSTables do
       add(:service_date, :date, null: false)
       add(:uid, :string, null: false)
       add(:rail_line, :rail_line, null: false)
-      add(:cars, :jsonb)
       add(:tags, :jsonb)
+      add(:cars, :jsonb)
+      add(:car_tags, :jsonb)
       add(:deleted, :boolean)
 
       timestamps()

--- a/priv/repo/migrations/20250617182608_ocs.exs
+++ b/priv/repo/migrations/20250617182608_ocs.exs
@@ -13,6 +13,7 @@ defmodule Orbit.Repo.Migrations.OCSTables do
       add(:trip_type, :string)
       add(:scheduled_departure, :utc_datetime)
       add(:scheduled_arrival, :utc_datetime)
+      add(:offset, :integer)
       add(:origin_station, :string)
       add(:destination_station, :string)
       add(:deleted, :boolean)

--- a/priv/repo/migrations/20250617182608_ocs.exs
+++ b/priv/repo/migrations/20250617182608_ocs.exs
@@ -1,0 +1,39 @@
+defmodule Orbit.Repo.Migrations.OCSTripsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:ocs_trips) do
+      add(:service_date, :date, null: false)
+      add(:uid, :string, null: false)
+      add(:train_uid, :string)
+      add(:prev_uid, :string)
+      add(:next_uid, :string)
+      add(:route, :string)
+      add(:rail_line, :rail_line, null: false)
+      add(:trip_type, :string)
+      add(:scheduled_departure, :utc_datetime)
+      add(:scheduled_arrival, :utc_datetime)
+      add(:origin_station, :string)
+      add(:destination_station, :string)
+      add(:deleted, :boolean)
+
+      timestamps()
+    end
+
+    create unique_index(:ocs_trips, [:service_date, :uid, :rail_line])
+    create index(:ocs_trips, [:service_date, :train_uid])
+
+    create table(:ocs_trains) do
+      add(:service_date, :date, null: false)
+      add(:uid, :string, null: false)
+      add(:rail_line, :rail_line, null: false)
+      add(:cars, :jsonb)
+      add(:tags, :jsonb)
+      add(:deleted, :boolean)
+
+      timestamps()
+    end
+
+    create unique_index(:ocs_trains, [:service_date, :uid, :rail_line])
+  end
+end

--- a/test/orbit/ocs/train_test.exs
+++ b/test/orbit/ocs/train_test.exs
@@ -1,0 +1,70 @@
+defmodule Orbit.Ocs.TrainTest do
+  use Orbit.DataCase
+
+  alias Orbit.Ocs.Train
+
+  test "create" do
+    %Train{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "TRAIN_UID",
+      cars: ["1877", "1876", "1811", "1812", "1808", "1809"],
+      tags: ["K", "K", "K", "", "", ""]
+    }
+  end
+
+  test "insert into the database" do
+    %Train{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "TRAIN_UID",
+      cars: ["1877", "1876", "1811", "1812", "1808", "1809"],
+      tags: ["K", "K", "K", "", "", ""]
+    }
+    |> Train.changeset()
+    |> Repo.insert!()
+  end
+
+  test "upsert" do
+    %Train{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "TRAIN_UID",
+      cars: ["1877", "1876", "1811", "1812", "1808", "1809"]
+    }
+    |> Train.changeset()
+    |> Repo.insert!()
+
+    %Train{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "TRAIN_UID",
+      cars: ["1877", "1876", "1811", "1812", "1808", "1810"],
+      tags: ["K", "K", "K", "", "", ""]
+    }
+    |> Train.changeset()
+    |> Repo.insert!(on_conflict: :replace_all, conflict_target: [:service_date, :uid, :rail_line])
+  end
+
+  test "unique constraint on service_date, uid, rail_line" do
+    %Train{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "TRAIN_UID",
+      cars: ["1877", "1876", "1811", "1812", "1808", "1809"]
+    }
+    |> Train.changeset()
+    |> Repo.insert!()
+
+    assert_raise Ecto.InvalidChangesetError, fn ->
+      %Train{
+        service_date: Util.Time.current_service_date(),
+        rail_line: :red,
+        uid: "TRAIN_UID",
+        cars: ["1877", "1876", "1811", "1812", "1808", "1809"]
+      }
+      |> Train.changeset()
+      |> Repo.insert!()
+    end
+  end
+end

--- a/test/orbit/ocs/train_test.exs
+++ b/test/orbit/ocs/train_test.exs
@@ -8,8 +8,9 @@ defmodule Orbit.Ocs.TrainTest do
       service_date: Util.Time.current_service_date(),
       rail_line: :red,
       uid: "TRAIN_UID",
+      tags: ["F"],
       cars: ["1877", "1876", "1811", "1812", "1808", "1809"],
-      tags: ["K", "K", "K", "", "", ""]
+      car_tags: ["K", "K", "K", "", "", ""]
     }
   end
 
@@ -18,8 +19,9 @@ defmodule Orbit.Ocs.TrainTest do
       service_date: Util.Time.current_service_date(),
       rail_line: :red,
       uid: "TRAIN_UID",
+      tags: ["F"],
       cars: ["1877", "1876", "1811", "1812", "1808", "1809"],
-      tags: ["K", "K", "K", "", "", ""]
+      car_tags: ["K", "K", "K", "", "", ""]
     }
     |> Train.changeset()
     |> Repo.insert!()
@@ -39,8 +41,9 @@ defmodule Orbit.Ocs.TrainTest do
       service_date: Util.Time.current_service_date(),
       rail_line: :red,
       uid: "TRAIN_UID",
+      tags: ["F"],
       cars: ["1877", "1876", "1811", "1812", "1808", "1810"],
-      tags: ["K", "K", "K", "", "", ""]
+      car_tags: ["K", "K", "K", "", "", ""]
     }
     |> Train.changeset()
     |> Repo.insert!(on_conflict: :replace_all, conflict_target: [:service_date, :uid, :rail_line])

--- a/test/orbit/ocs/trip_test.exs
+++ b/test/orbit/ocs/trip_test.exs
@@ -1,0 +1,125 @@
+defmodule Orbit.Ocs.TripTest do
+  use Orbit.DataCase
+
+  alias Orbit.Ocs.Trip
+
+  test "create" do
+    %Trip{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "9814A64F"
+    }
+  end
+
+  test "insert into the database" do
+    %Trip{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "9814A64F"
+    }
+    |> Trip.changeset()
+    |> Repo.insert!()
+  end
+
+  test "upsert with train UID into the database" do
+    %Trip{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "9814A64F"
+    }
+    |> Trip.changeset()
+    |> Repo.insert!()
+
+    %Trip{
+      service_date: Util.Time.current_service_date(),
+      rail_line: :red,
+      uid: "9814A64F",
+      train_uid: "TRAIN_UID"
+    }
+    |> Trip.changeset()
+    |> Repo.insert!(on_conflict: :replace_all, conflict_target: [:service_date, :rail_line, :uid])
+  end
+
+  test "unique constraint on service_date, uid, rail_line" do
+    today = Util.Time.current_service_date()
+
+    %Trip{
+      service_date: today,
+      rail_line: :red,
+      uid: "9814A64F"
+    }
+    |> Trip.changeset()
+    |> Repo.insert!()
+
+    %Trip{
+      service_date: today,
+      rail_line: :blue,
+      uid: "9814A64F"
+    }
+    |> Trip.changeset()
+    |> Repo.insert!()
+
+    assert_raise Ecto.InvalidChangesetError,
+                 fn ->
+                   %Trip{
+                     service_date: today,
+                     rail_line: :red,
+                     uid: "9814A64F"
+                   }
+                   |> Trip.changeset()
+                   |> Repo.insert!()
+                 end
+  end
+
+  test "changeset enforces non-null constraints" do
+    # null service_date
+    assert %{valid?: false} =
+             %Trip{
+               rail_line: :red,
+               uid: "9814A64F"
+             }
+             |> Trip.changeset()
+
+    # null rail_line
+    assert %{valid?: false} =
+             %Trip{
+               service_date: Util.Time.current_service_date(),
+               uid: "9814A64F"
+             }
+             |> Trip.changeset()
+
+    # null uid
+    assert %{valid?: false} =
+             %Trip{
+               rail_line: :red,
+               service_date: Util.Time.current_service_date()
+             }
+             |> Trip.changeset()
+  end
+
+  test "database enforces non-null constraints" do
+    # null service_date
+    assert_raise Postgrex.Error, fn ->
+      Repo.insert!(%Trip{
+        rail_line: :red,
+        uid: "9814A64F"
+      })
+    end
+
+    # null rail_line
+    assert_raise Postgrex.Error, fn ->
+      Repo.insert!(%Trip{
+        service_date: Util.Time.current_service_date(),
+        uid: "9814A64F"
+      })
+    end
+
+    # null uid
+    assert_raise Postgrex.Error, fn ->
+      Repo.insert!(%Trip{
+        rail_line: :red,
+        service_date: Util.Time.current_service_date()
+      })
+    end
+  end
+end


### PR DESCRIPTION
Asana Task: [🛠 Set up data structures for OCS trainsheets](https://app.asana.com/1/15492006741476/project/1206105669438487/task/1210389787136611)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Create two new tables to populate with OCS data as we receive it:
1. ocs_trips
2. ocs_trains

NB: I'm not using foreign key constraints here, as I don't have enough certainty about the order of insertion. So I'm expecting using this data to be best-effort.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
