### PR TITLE
feat: create sidebar

### DIFF
--- a/js/components/app.tsx
+++ b/js/components/app.tsx
@@ -4,7 +4,7 @@ import { ORBIT_BL_FFD } from "../groups";
 import { paths } from "../paths";
 import { AppcuesTrackPage } from "./appcues";
 import { Header } from "./header";
-import { Ladders } from "./ladderPage/ladder";
+import { LadderPage } from "./ladderPage/ladderPage";
 import { LandingPage } from "./landingPage";
 import { HelpMenu, Menu } from "./menus";
 import { Operators } from "./operators";
@@ -77,7 +77,7 @@ const router = createBrowserRouter([
       },
       {
         path: paths.ladder,
-        element: <Ladders routeId="Red" />,
+        element: <LadderPage routeId="Red" />
       },
       {
         path: paths.operators,

--- a/js/components/app.tsx
+++ b/js/components/app.tsx
@@ -77,7 +77,7 @@ const router = createBrowserRouter([
       },
       {
         path: paths.ladder,
-        element: <LadderPage routeId="Red" />
+        element: <LadderPage routeId="Red" />,
       },
       {
         path: paths.operators,

--- a/js/components/ladderPage/ladder.tsx
+++ b/js/components/ladderPage/ladder.tsx
@@ -7,6 +7,7 @@ import {
   vehiclesFromPositionsAndTripUpdates,
 } from "../../models/vehicle";
 import { StopStatus } from "../../models/vehiclePosition";
+import { SideBarSelection } from "../sideBar/sidebar";
 import { height } from "./height";
 import { Train } from "./train";
 import {
@@ -14,9 +15,15 @@ import {
   TrainThemes,
   trainThemesByRoutePattern,
 } from "./trainTheme";
-import { ReactElement } from "react";
+import { Dispatch, ReactElement, SetStateAction } from "react";
 
-export const Ladders = ({ routeId }: { routeId: RouteId }): ReactElement => {
+export const Ladders = ({
+  routeId,
+  setSideBarSelection,
+}: {
+  routeId: RouteId;
+  setSideBarSelection: Dispatch<SetStateAction<SideBarSelection | null>>;
+}): ReactElement => {
   const tripUpdates = useTripUpdates();
   const vehiclePositions = useVehiclePositions();
   const stationLists = Stations[routeId];
@@ -50,7 +57,7 @@ export const Ladders = ({ routeId }: { routeId: RouteId }): ReactElement => {
 
   return (
     <>
-      <span>
+      {/* <span>
         Status:{" "}
         {vehiclePositions !== null && tripUpdates !== null ?
           <>
@@ -58,12 +65,12 @@ export const Ladders = ({ routeId }: { routeId: RouteId }): ReactElement => {
             tripUpdates)
           </>
         : <>Loading...</>}
-      </span>
+      </span> */}
 
       {/* outer <div> prevents horizontal overflow from affecting the overall page layout
       inner <div> enables horizontal overflow (scrolling) for the 3 StationLists
       ^ this should potentially be handled in a future <LadderPage />. */}
-      <div className="overflow-x-hidden">
+      <div className="overflow-x-hidden mt-72">
         <div className="relative flex xl:justify-center overflow-x-auto snap-x snap-mandatory">
           {Array.from(vehiclesByBranch.entries()).map(
             ([stationList, vehicles], index) => (
@@ -71,6 +78,7 @@ export const Ladders = ({ routeId }: { routeId: RouteId }): ReactElement => {
                 key={index}
                 ladderConfig={stationList}
                 vehicles={vehicles}
+                setSideBarSelection={setSideBarSelection}
               />
             ),
           )}
@@ -83,9 +91,11 @@ export const Ladders = ({ routeId }: { routeId: RouteId }): ReactElement => {
 const TrainsAndStations = ({
   ladderConfig,
   vehicles,
+  setSideBarSelection,
 }: {
   ladderConfig: LadderConfig;
   vehicles: Vehicle[];
+  setSideBarSelection: Dispatch<SetStateAction<SideBarSelection | null>>;
 }): ReactElement => {
   return (
     <div className="relative flex snap-center snap-always">
@@ -130,7 +140,13 @@ const TrainsAndStations = ({
             style={{ position: "absolute", top: `${px}px` }}
             className={direction === 0 ? "left-[24px]" : "right-[24px]"}
           >
-            <Train theme={trainTheme} label={vp.label} direction={direction} />
+            <Train
+              theme={trainTheme}
+              label={vp.label}
+              consist={vp.cars}
+              direction={direction}
+              setSideBarSelection={setSideBarSelection}
+            />
           </div>
         );
       })}

--- a/js/components/ladderPage/ladder.tsx
+++ b/js/components/ladderPage/ladder.tsx
@@ -7,7 +7,7 @@ import {
   vehiclesFromPositionsAndTripUpdates,
 } from "../../models/vehicle";
 import { StopStatus } from "../../models/vehiclePosition";
-import { SideBarSelection } from "../sideBar/sidebar";
+import { SideBarSelection } from "../sideBar/sideBar";
 import { height } from "./height";
 import { Train } from "./train";
 import {

--- a/js/components/ladderPage/ladder.tsx
+++ b/js/components/ladderPage/ladder.tsx
@@ -56,30 +56,18 @@ export const Ladders = ({
   );
 
   return (
-    <>
-      {/* <span>
-        Status:{" "}
-        {vehiclePositions !== null && tripUpdates !== null ?
-          <>
-            Connected ({vehiclePositions.length} vehicles, {tripUpdates.length}{" "}
-            tripUpdates)
-          </>
-        : <>Loading...</>}
-      </span> */}
-
-      <div className="relative flex flex-grow xl:justify-center overflow-x-auto snap-x snap-mandatory">
-        {Array.from(vehiclesByBranch.entries()).map(
-          ([stationList, vehicles], index) => (
-            <TrainsAndStations
-              key={index}
-              ladderConfig={stationList}
-              vehicles={vehicles}
-              setSideBarSelection={setSideBarSelection}
-            />
-          ),
-        )}
-      </div>
-    </>
+    <div className="relative flex flex-grow xl:justify-center overflow-x-auto snap-x snap-mandatory">
+      {Array.from(vehiclesByBranch.entries()).map(
+        ([stationList, vehicles], index) => (
+          <TrainsAndStations
+            key={index}
+            ladderConfig={stationList}
+            vehicles={vehicles}
+            setSideBarSelection={setSideBarSelection}
+          />
+        ),
+      )}
+    </div>
   );
 };
 

--- a/js/components/ladderPage/ladder.tsx
+++ b/js/components/ladderPage/ladder.tsx
@@ -67,22 +67,17 @@ export const Ladders = ({
         : <>Loading...</>}
       </span> */}
 
-      {/* outer <div> prevents horizontal overflow from affecting the overall page layout
-      inner <div> enables horizontal overflow (scrolling) for the 3 StationLists
-      ^ this should potentially be handled in a future <LadderPage />. */}
-      <div className="overflow-x-hidden mt-72">
-        <div className="relative flex xl:justify-center overflow-x-auto snap-x snap-mandatory">
-          {Array.from(vehiclesByBranch.entries()).map(
-            ([stationList, vehicles], index) => (
-              <TrainsAndStations
-                key={index}
-                ladderConfig={stationList}
-                vehicles={vehicles}
-                setSideBarSelection={setSideBarSelection}
-              />
-            ),
-          )}
-        </div>
+      <div className="relative flex flex-grow xl:justify-center overflow-x-auto snap-x snap-mandatory">
+        {Array.from(vehiclesByBranch.entries()).map(
+          ([stationList, vehicles], index) => (
+            <TrainsAndStations
+              key={index}
+              ladderConfig={stationList}
+              vehicles={vehicles}
+              setSideBarSelection={setSideBarSelection}
+            />
+          ),
+        )}
       </div>
     </>
   );

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -18,12 +18,14 @@ export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
       >
         <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />
       </div>
-      <SideBar
-        selection={sideBarSelection ?? null}
-        close={() => {
-          setSideBarSelection(null);
-        }}
-      />
+      {sideBarSelection ?
+        <SideBar
+          selection={sideBarSelection}
+          close={() => {
+            setSideBarSelection(null);
+          }}
+        />
+      : null}
     </div>
   );
 };

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -1,4 +1,5 @@
 import { RouteId } from "../../models/common";
+import { className } from "../../util/dom";
 import { SideBar, SideBarSelection } from "../sideBar/sidebar";
 import { Ladders } from "./ladder";
 import { ReactElement, useState } from "react";
@@ -8,8 +9,15 @@ export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
     useState<SideBarSelection | null>(null);
 
   return (
-    <div className="relative h-screen flex items-center justify-center">
-      <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />
+    <div className="relative flex h-screen items-center justify-center">
+      <div
+        className={className([
+          "overflow-x-hidden mt-72",
+          sideBarSelection ? "translate-x-80" : "translate-x-0",
+        ])}
+      >
+        <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />
+      </div>
       <SideBar
         selection={sideBarSelection ?? null}
         close={() => {

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -15,7 +15,7 @@ export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
     <div className="relative flex h-screen items-center justify-center overflow-y-auto">
       <div
         className={className([
-          "flex-grow overflow-x-hidden mt-72 transition-all duration-300 ease-in-out",
+          "flex-grow overflow-x-auto overflow-y-auto mt-72 transition-all duration-300 ease-in-out",
           (
             sideBarSelection &&
             window.innerWidth < MIN_LADDERS_CONTENT_WIDTH_PX + SIDEBAR_WIDTH_PX

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -12,7 +12,7 @@ export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
     useState<SideBarSelection | null>(null);
 
   return (
-    <div className="relative flex h-screen items-center justify-center overflow-hidden">
+    <div className="relative flex h-screen items-center justify-center overflow-y-auto">
       <div
         className={className([
           "flex-grow overflow-x-hidden mt-72 transition-all duration-300 ease-in-out",

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -1,19 +1,27 @@
 import { RouteId } from "../../models/common";
 import { className } from "../../util/dom";
-import { SideBar, SideBarSelection } from "../sideBar/sidebar";
+import { SideBar, SideBarSelection } from "../sideBar/sideBar";
 import { Ladders } from "./ladder";
 import { ReactElement, useState } from "react";
 
 export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
+  const SIDEBAR_WIDTH_PX = 320;
+  const MIN_LADDERS_CONTENT_WIDTH_PX = 1248;
+
   const [sideBarSelection, setSideBarSelection] =
     useState<SideBarSelection | null>(null);
 
   return (
-    <div className="relative flex h-screen items-center justify-center">
+    <div className="relative flex h-screen items-center justify-center overflow-hidden">
       <div
         className={className([
-          "overflow-x-hidden mt-72",
-          sideBarSelection ? "translate-x-80" : "translate-x-0",
+          "flex-grow overflow-x-hidden mt-72 transition-all duration-300 ease-in-out",
+          (
+            sideBarSelection &&
+            window.innerWidth < MIN_LADDERS_CONTENT_WIDTH_PX + SIDEBAR_WIDTH_PX
+          ) ?
+            "ml-80"
+          : "ml-0",
         ])}
       >
         <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -7,18 +7,15 @@ export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
   const [sideBarSelection, setSideBarSelection] =
     useState<SideBarSelection | null>(null);
 
-  console.log(sideBarSelection);
   return (
     <div className="relative h-screen flex items-center justify-center">
-      {sideBarSelection ?
-        <SideBar
-          selection={sideBarSelection}
-          close={() => {
-            setSideBarSelection(null);
-          }}
-        />
-      : null}
       <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />
+      <SideBar
+        selection={sideBarSelection ?? null}
+        close={() => {
+          setSideBarSelection(null);
+        }}
+      />
     </div>
   );
 };

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -5,9 +5,6 @@ import { Ladders } from "./ladder";
 import { ReactElement, useState } from "react";
 
 export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
-  const SIDEBAR_WIDTH_PX = 320;
-  const MIN_LADDERS_CONTENT_WIDTH_PX = 1248;
-
   const [sideBarSelection, setSideBarSelection] =
     useState<SideBarSelection | null>(null);
 
@@ -15,13 +12,8 @@ export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
     <div className="relative flex h-screen items-center justify-center overflow-y-auto">
       <div
         className={className([
-          "flex-grow overflow-x-auto overflow-y-auto mt-72 transition-all duration-300 ease-in-out",
-          (
-            sideBarSelection &&
-            window.innerWidth < MIN_LADDERS_CONTENT_WIDTH_PX + SIDEBAR_WIDTH_PX
-          ) ?
-            "ml-80"
-          : "ml-0",
+          "flex overflow-auto mt-72 transition-all duration-300 ease-in-out",
+          sideBarSelection && "ml-80 2xl:ml-0",
         ])}
       >
         <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />

--- a/js/components/ladderPage/ladderPage.tsx
+++ b/js/components/ladderPage/ladderPage.tsx
@@ -1,0 +1,24 @@
+import { RouteId } from "../../models/common";
+import { SideBar, SideBarSelection } from "../sideBar/sidebar";
+import { Ladders } from "./ladder";
+import { ReactElement, useState } from "react";
+
+export const LadderPage = ({ routeId }: { routeId: RouteId }): ReactElement => {
+  const [sideBarSelection, setSideBarSelection] =
+    useState<SideBarSelection | null>(null);
+
+  console.log(sideBarSelection);
+  return (
+    <div className="relative h-screen flex items-center justify-center">
+      {sideBarSelection ?
+        <SideBar
+          selection={sideBarSelection}
+          close={() => {
+            setSideBarSelection(null);
+          }}
+        />
+      : null}
+      <Ladders routeId={routeId} setSideBarSelection={setSideBarSelection} />
+    </div>
+  );
+};

--- a/js/components/ladderPage/train.tsx
+++ b/js/components/ladderPage/train.tsx
@@ -1,4 +1,4 @@
-import { CarId } from "../../models/common";
+import { CarId, DirectionId } from "../../models/common";
 import { className } from "../../util/dom";
 import { SideBarSelection } from "../sideBar/sideBar";
 import { TrainTheme } from "./trainTheme";
@@ -17,7 +17,7 @@ export const Train = ({
   label: string;
   consist: CarId[];
   highlight?: boolean;
-  direction: number;
+  direction: DirectionId;
   className?: string;
   setSideBarSelection: Dispatch<SetStateAction<SideBarSelection | null>>;
 }): ReactElement => {
@@ -34,7 +34,9 @@ export const Train = ({
         ])}
         onClick={() => {
           const sideBarSelection: SideBarSelection = {
+            label: label,
             consist: consist,
+            direction: direction,
           };
           setSideBarSelection(sideBarSelection);
         }}

--- a/js/components/ladderPage/train.tsx
+++ b/js/components/ladderPage/train.tsx
@@ -1,5 +1,7 @@
+import { ORBIT_RL_SIDEBAR } from "../../groups";
 import { CarId, DirectionId } from "../../models/common";
 import { className } from "../../util/dom";
+import { getMetaContent } from "../../util/metadata";
 import { SideBarSelection } from "../sideBar/sideBar";
 import { TrainTheme } from "./trainTheme";
 import { Dispatch, ReactElement, SetStateAction } from "react";
@@ -21,6 +23,8 @@ export const Train = ({
   className?: string;
   setSideBarSelection: Dispatch<SetStateAction<SideBarSelection | null>>;
 }): ReactElement => {
+  const userGroups = getMetaContent("userGroups");
+
   const orientation = direction == 0 ? "right-0" : "left-0";
   return (
     <div className="relative">
@@ -33,12 +37,14 @@ export const Train = ({
           extraClassName,
         ])}
         onClick={() => {
-          const sideBarSelection: SideBarSelection = {
-            label: label,
-            consist: consist,
-            direction: direction,
-          };
-          setSideBarSelection(sideBarSelection);
+          if (userGroups?.split(",").includes(ORBIT_RL_SIDEBAR)) {
+            const sideBarSelection: SideBarSelection = {
+              label: label,
+              consist: consist,
+              direction: direction,
+            };
+            setSideBarSelection(sideBarSelection);
+          }
         }}
       >
         {label}

--- a/js/components/ladderPage/train.tsx
+++ b/js/components/ladderPage/train.tsx
@@ -1,31 +1,43 @@
+import { CarId } from "../../models/common";
 import { className } from "../../util/dom";
+import { SideBarSelection } from "../sideBar/sidebar";
 import { TrainTheme } from "./trainTheme";
-import { ReactElement } from "react";
+import { Dispatch, ReactElement, SetStateAction } from "react";
 
 export const Train = ({
   theme,
   label,
+  consist,
   highlight,
   direction,
   className: extraClassName,
+  setSideBarSelection,
 }: {
   theme: TrainTheme;
   label: string;
+  consist: CarId[];
   highlight?: boolean;
   direction: number;
   className?: string;
+  setSideBarSelection: Dispatch<SetStateAction<SideBarSelection | null>>;
 }): ReactElement => {
   const orientation = direction == 0 ? "right-0" : "left-0";
   return (
     <div className="relative">
       {/* train label */}
-      <div
+      <button
         className={className([
           "m-1 relative flex items-center justify-center rounded-3xl w-24 h-10 font-semibold",
           highlight ? "border-[3px] animate-pulse" : "border",
           theme.borderColor,
           extraClassName,
         ])}
+        onClick={() => {
+          const sideBarSelection: SideBarSelection = {
+            consist: consist,
+          };
+          setSideBarSelection(sideBarSelection);
+        }}
       >
         {label}
 
@@ -61,7 +73,7 @@ export const Train = ({
             ])}
           />
         </div>
-      </div>
+      </button>
     </div>
   );
 };

--- a/js/components/ladderPage/train.tsx
+++ b/js/components/ladderPage/train.tsx
@@ -1,6 +1,6 @@
 import { CarId } from "../../models/common";
 import { className } from "../../util/dom";
-import { SideBarSelection } from "../sideBar/sidebar";
+import { SideBarSelection } from "../sideBar/sideBar";
 import { TrainTheme } from "./trainTheme";
 import { Dispatch, ReactElement, SetStateAction } from "react";
 

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -1,0 +1,28 @@
+import { CarId } from "../../models/common";
+import { ReactElement } from "react";
+
+export type SideBarSelection = {
+  consist: CarId[];
+};
+
+export const SideBar = ({
+  selection: { consist },
+  close,
+}: {
+  selection: SideBarSelection;
+  close: () => void;
+}): ReactElement => {
+  return (
+    <div className="fixed left-0 w-80 h-screen bg-gray-200">
+
+      <button
+        className="absolute m-3 top-0 right-0 h-4 w-4 hover:fill-slate-700"
+        onClick={close}
+      >
+        <img src="/images/close.svg" alt="close sidebar" />
+      </button>
+
+      <div className="mt-14 px-4">{consist}</div>
+    </div>
+  );
+};

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -1,9 +1,12 @@
-import { CarId } from "../../models/common";
+import { CarId, DirectionId } from "../../models/common";
+import { consistDirectionalOrder } from "../../util/consist";
 import { className } from "../../util/dom";
 import { ReactElement } from "react";
 
 export type SideBarSelection = {
+  label: CarId;
   consist: CarId[];
+  direction: DirectionId;
 };
 
 export const SideBar = ({
@@ -13,10 +16,21 @@ export const SideBar = ({
   selection: SideBarSelection | null;
   close: () => void;
 }): ReactElement => {
+  const consist: CarId[] =
+    selection ?
+      consistDirectionalOrder(
+        selection.label,
+        selection.consist,
+        selection.direction,
+      )
+    : [""]; // TODO: what to do if no selection?
+
+  const leadCarIndex =
+    selection && (selection.direction === 0 ? 0 : selection.consist.length - 1);
   return (
     <div
       className={className([
-        "absolute left-0 w-80 h-screen bg-gray-200 transition-transform duration-300 ease-in-out",
+        "absolute flex-grow left-0 w-80 h-dvh bg-gray-200 transition-transform duration-300 ease-in-out",
         selection ? "translate-x-0" : "-translate-x-full",
       ])}
     >
@@ -27,7 +41,19 @@ export const SideBar = ({
         <img src="/images/close.svg" alt="close sidebar" />
       </button>
 
-      <div className="mt-14 px-4">{selection ? selection.consist : ""}</div>
+      <div className="mt-14 px-4 flex">
+        {consist.map((label, index) => (
+          <div
+            key={index}
+            className={className([
+              "mr-2",
+              index === leadCarIndex ? "font-bold text-2xl" : "pt-1.5",
+            ])}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -23,14 +23,14 @@ export const SideBar = ({
         selection.consist,
         selection.direction,
       )
-    : [""]; // TODO: what to do if no selection?
+    : [""];
 
   const leadCarIndex =
     selection && (selection.direction === 0 ? 0 : selection.consist.length - 1);
   return (
     <div
       className={className([
-        "absolute flex-grow left-0 w-80 h-dvh bg-gray-200 transition-transform duration-300 ease-in-out",
+        "absolute flex-grow left-0 w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
         selection ? "translate-x-0" : "-translate-x-full",
       ])}
     >

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -30,7 +30,7 @@ export const SideBar = ({
   return (
     <div
       className={className([
-        "absolute flex-grow left-0 w-full sm:w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
+        "fixed flex-grow left-0 w-full sm:w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
         selection ? "translate-x-0" : "-translate-x-full",
       ])}
     >

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -1,4 +1,5 @@
 import { CarId } from "../../models/common";
+import { className } from "../../util/dom";
 import { ReactElement } from "react";
 
 export type SideBarSelection = {
@@ -6,15 +7,21 @@ export type SideBarSelection = {
 };
 
 export const SideBar = ({
-  selection: { consist },
+  selection,
   close,
 }: {
-  selection: SideBarSelection;
+  selection: SideBarSelection | null;
   close: () => void;
 }): ReactElement => {
   return (
-    <div className="fixed left-0 w-80 h-screen bg-gray-200">
-
+    <div
+      className={className([
+        "fixed left-0 w-80 h-screen bg-gray-200",
+        selection ?
+          "transition-transform duration-300 ease-in-out translate-x-0"
+        : "-translate-x-full",
+      ])}
+    >
       <button
         className="absolute m-3 top-0 right-0 h-4 w-4 hover:fill-slate-700"
         onClick={close}
@@ -22,7 +29,7 @@ export const SideBar = ({
         <img src="/images/close.svg" alt="close sidebar" />
       </button>
 
-      <div className="mt-14 px-4">{consist}</div>
+      <div className="mt-14 px-4">{selection ? selection.consist : ""}</div>
     </div>
   );
 };

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -31,9 +31,7 @@ export const SideBar = ({
     <div
       className={className([
         "fixed flex-grow left-0 w-full sm:w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
-        selection ?
-          "absolute inset-y-0 left-0 animate-slide-in-from-left"
-        : null,
+        selection ? "animate-slide-in-from-left" : null,
       ])}
     >
       <button

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -16,10 +16,8 @@ export const SideBar = ({
   return (
     <div
       className={className([
-        "fixed left-0 w-80 h-screen bg-gray-200",
-        selection ?
-          "transition-transform duration-300 ease-in-out translate-x-0"
-        : "-translate-x-full",
+        "absolute w-80 h-screen bg-gray-200 transition-all duration-300 ease-in-out",
+        selection ? "left-0" : "-left-[100%]",
       ])}
     >
       <button

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -30,7 +30,7 @@ export const SideBar = ({
   return (
     <div
       className={className([
-        "absolute flex-grow left-0 w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
+        "absolute flex-grow left-0 w-full sm:w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
         selection ? "translate-x-0" : "-translate-x-full",
       ])}
     >

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -16,8 +16,8 @@ export const SideBar = ({
   return (
     <div
       className={className([
-        "absolute w-80 h-screen bg-gray-200 transition-all duration-300 ease-in-out",
-        selection ? "left-0" : "-left-[100%]",
+        "absolute left-0 w-80 h-screen bg-gray-200 transition-transform duration-300 ease-in-out",
+        selection ? "translate-x-0" : "-translate-x-full",
       ])}
     >
       <button

--- a/js/components/sideBar/sidebar.tsx
+++ b/js/components/sideBar/sidebar.tsx
@@ -31,7 +31,9 @@ export const SideBar = ({
     <div
       className={className([
         "fixed flex-grow left-0 w-full sm:w-80 h-dvh bg-gray-100 transition-transform duration-300 ease-in-out",
-        selection ? "translate-x-0" : "-translate-x-full",
+        selection ?
+          "absolute inset-y-0 left-0 animate-slide-in-from-left"
+        : null,
       ])}
     >
       <button

--- a/js/groups.ts
+++ b/js/groups.ts
@@ -1,1 +1,4 @@
 export const ORBIT_BL_FFD = "orbit-bl-ffd";
+
+// TODO: potentially update RL sidebar group name
+export const ORBIT_RL_SIDEBAR = "orbit-rl-sidebar";

--- a/js/test/components/ladderPage/ladder.test.tsx
+++ b/js/test/components/ladderPage/ladder.test.tsx
@@ -37,7 +37,9 @@ describe("Ladder", () => {
   test("shows station names", () => {
     mockUseVehiclePositions.mockReturnValue([]);
     mockUseTripUpdates.mockReturnValue([]);
-    const view = render(<Ladders routeId={"Red"} />);
+    const view = render(
+      <Ladders routeId={"Red"} setSideBarSelection={jest.fn()} />,
+    );
     expect(view.getByText("Alewife")).toBeInTheDocument();
     expect(view.getByText("Ashmont")).toBeInTheDocument();
     expect(view.getByText("Braintree")).toBeInTheDocument();
@@ -71,7 +73,9 @@ describe("Ladder", () => {
     ]);
     mockUseTripUpdates.mockReturnValue([]);
 
-    const view = render(<Ladders routeId="Red" />);
+    const view = render(
+      <Ladders routeId="Red" setSideBarSelection={jest.fn()} />,
+    );
     expect(view.getByText("1877")).toBeInTheDocument();
     expect(view.getByText("1888")).toBeInTheDocument();
     expect(view.getByText("1889")).toBeInTheDocument();
@@ -111,7 +115,9 @@ describe("Ladder", () => {
           }),
         ]);
 
-        const view = render(<Ladders routeId="Red" />);
+        const view = render(
+          <Ladders routeId="Red" setSideBarSelection={jest.fn()} />,
+        );
         expect(view.getByText("1888")).toBeInTheDocument();
         expect(view.getByText("1888")).toHaveClass("border-tangerine");
         expect(view.getByText("1889")).toBeInTheDocument();
@@ -169,7 +175,9 @@ describe("Ladder", () => {
           }),
         ]);
 
-        const view = render(<Ladders routeId="Red" />);
+        const view = render(
+          <Ladders routeId="Red" setSideBarSelection={jest.fn()} />,
+        );
 
         // Ashmont defaults to orange
         expect(view.getByText("1888")).toBeInTheDocument();

--- a/js/test/components/ladderPage/ladderPage.test.tsx
+++ b/js/test/components/ladderPage/ladderPage.test.tsx
@@ -1,0 +1,48 @@
+import { LadderPage } from "../../../components/ladderPage/ladderPage";
+import { useTripUpdates } from "../../../hooks/useTripUpdates";
+import { useVehiclePositions } from "../../../hooks/useVehiclePositions";
+import {
+  tripUpdateFactory,
+  vehiclePositionFactory,
+} from "../../helpers/factory";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("../../../hooks/useVehiclePositions", () => ({
+  __esModule: true,
+  useVehiclePositions: jest.fn(),
+}));
+const mockUseVehiclePositions = useVehiclePositions as jest.MockedFunction<
+  typeof useVehiclePositions
+>;
+mockUseVehiclePositions.mockReturnValue([vehiclePositionFactory.build()]);
+
+jest.mock("../../../hooks/useTripUpdates", () => ({
+  __esModule: true,
+  useTripUpdates: jest.fn(),
+}));
+const mockUseTripUpdates = useTripUpdates as jest.MockedFunction<
+  typeof useTripUpdates
+>;
+mockUseTripUpdates.mockReturnValue([tripUpdateFactory.build()]);
+
+describe("LadderPage SideBar", () => {
+  test("clicking on train pill opens sidebar", async () => {
+    const user = userEvent.setup();
+    const view = render(<LadderPage routeId="Red" />);
+    await user.click(view.getByText("1877"));
+    expect(
+      view.getByRole("button", { name: "close sidebar" }),
+    ).toBeInTheDocument();
+  });
+
+  test("can close SideBar with close button", async () => {
+    const user = userEvent.setup();
+    const view = render(<LadderPage routeId="Red" />);
+    await user.click(view.getByText("1877"));
+    await user.click(view.getByRole("button", { name: "close sidebar" }));
+    expect(
+      view.queryByRole("button", { name: "close sidebar" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/js/test/components/ladderPage/train.test.tsx
+++ b/js/test/components/ladderPage/train.test.tsx
@@ -3,27 +3,38 @@ import {
   TrainTheme,
   TrainThemes,
 } from "../../../components/ladderPage/trainTheme";
+import { CarId } from "../../../models/common";
 import { render } from "@testing-library/react";
 
 describe("Train", () => {
+  const consist: CarId[] = ["1851", "1850", "1883", "1882", "1881", "1880"];
+
   test("shows label", () => {
     const view = render(
-      <Train theme={TrainThemes.crimson} label="1875" direction={0} />,
+      <Train
+        theme={TrainThemes.crimson}
+        label="1851"
+        direction={0}
+        consist={consist}
+        setSideBarSelection={jest.fn()}
+      />,
     );
-    expect(view.getByText("1875")).toBeInTheDocument();
+    expect(view.getByText("1851")).toBeInTheDocument();
   });
 
   test("accepts additional properties", () => {
     const view = render(
       <Train
         theme={TrainThemes.crimson}
-        label="1875"
+        label="1851"
         highlight={true}
         direction={0}
+        consist={consist}
+        setSideBarSelection={jest.fn()}
         className={""} // Empty, but still worth making sure it doesn't error :-)
       />,
     );
-    expect(view.getByText("1875")).toBeInTheDocument();
+    expect(view.getByText("1851")).toBeInTheDocument();
   });
 
   test("renders based on provided theme", () => {
@@ -34,13 +45,15 @@ describe("Train", () => {
     const view = render(
       <Train
         theme={theme}
-        label="1875"
+        label="1880"
         highlight={true}
-        direction={0}
+        direction={1}
+        consist={consist}
+        setSideBarSelection={jest.fn()}
         className={""} // Empty, but still worth making sure it doesn't error :-)
       />,
     );
-    expect(view.getByText("1875")).toBeInTheDocument();
-    expect(view.getByText("1875")).toHaveClass("some-border-color");
+    expect(view.getByText("1880")).toBeInTheDocument();
+    expect(view.getByText("1880")).toHaveClass("some-border-color");
   });
 });

--- a/js/test/util/consist.test.ts
+++ b/js/test/util/consist.test.ts
@@ -1,0 +1,76 @@
+import { consistDirectionalOrder } from "../../util/consist";
+
+describe("consistDirectionalOrder", () => {
+  test("correctly orders southbound consists", () => {
+    // already in the desired order (lead car on left)
+    const consist0 = ["1877", "1876", "1807", "1806", "1815", "1814"];
+    const fixedConsist0 = consistDirectionalOrder("1877", consist0, 0);
+
+    // consist in reverse of desired order (lead car on right)
+    const consist1 = ["1814", "1815", "1806", "1807", "1876", "1877"];
+    const fixedConsist1 = consistDirectionalOrder("1877", consist1, 0);
+
+    expect(fixedConsist0).toStrictEqual([
+      "1877",
+      "1876",
+      "1807",
+      "1806",
+      "1815",
+      "1814",
+    ]);
+    expect(fixedConsist1).toStrictEqual([
+      "1877",
+      "1876",
+      "1807",
+      "1806",
+      "1815",
+      "1814",
+    ]);
+  });
+
+  test("correctly orders northbound consists", () => {
+    // already in the desired order (lead car on right)
+    const consist0 = ["1877", "1876", "1807", "1806", "1815", "1814"];
+    const fixedConsist0 = consistDirectionalOrder("1814", consist0, 1);
+
+    // consist in reverse of desired order (lead car on left)
+    const consist1 = ["1814", "1815", "1806", "1807", "1876", "1877"];
+    const fixedConsist1 = consistDirectionalOrder("1814", consist1, 1);
+
+    expect(fixedConsist0).toStrictEqual([
+      "1877",
+      "1876",
+      "1807",
+      "1806",
+      "1815",
+      "1814",
+    ]);
+    expect(fixedConsist1).toStrictEqual([
+      "1877",
+      "1876",
+      "1807",
+      "1806",
+      "1815",
+      "1814",
+    ]);
+  });
+
+  test("logs error and returns unmodified consist if lead car not found", () => {
+    console.error = jest.fn();
+    const consist = ["1877", "1876", "1807", "1806", "1815", "1814"];
+    const fixedConsist = consistDirectionalOrder("1806", consist, 1);
+
+    expect(fixedConsist).toStrictEqual([
+      "1877",
+      "1876",
+      "1807",
+      "1806",
+      "1815",
+      "1814",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      "vehicle label 1806 is not the lead car in consist",
+      consist,
+    );
+  });
+});

--- a/js/util/consist.ts
+++ b/js/util/consist.ts
@@ -1,0 +1,22 @@
+import { CarId, DirectionId } from "../models/common";
+
+export const consistDirectionalOrder = (
+  label: CarId,
+  consist: CarId[],
+  direction_id: DirectionId,
+) => {
+  const expectedLeadIndex = direction_id === 0 ? 0 : consist.length - 1;
+  const expectedLastIndex = direction_id === 0 ? consist.length - 1 : 0;
+
+  if (label === consist[expectedLeadIndex]) {
+    return consist;
+  } else if (label === consist[expectedLastIndex]) {
+    return [...consist].reverse();
+  } else {
+    console.error(
+      `vehicle label ${label} is not the lead car in consist`,
+      consist,
+    );
+    return consist;
+  }
+};

--- a/lib/orbit_web/auth/strategy/fake_oidcc.ex
+++ b/lib/orbit_web/auth/strategy/fake_oidcc.ex
@@ -4,7 +4,7 @@ defmodule OrbitWeb.Auth.Strategy.FakeOidcc do
 
   @impl Ueberauth.Strategy
   def handle_request!(conn) do
-    groups = ["orbit-admin", "orbit-bl-ffd"]
+    groups = ["orbit-admin", "orbit-bl-ffd", "orbit-rl-sidebar"]
 
     conn
     |> put_resp_content_type("text/html")

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -52,11 +52,16 @@ export default {
       animation: {
         "dash-spin-ccw": "dashoffset-spin 2s linear infinite",
         "dash-spin-cw": "dashoffset-spin 3s linear infinite reverse",
+        "slide-in-from-left": "slide-in-from-left 0.25s",
       },
       keyframes: {
         "dashoffset-spin": {
           "0%": { "stroke-dashoffset": "0" },
           "100%": { "stroke-dashoffset": "1" },
+        },
+        "slide-in-from-left": {
+          "0%": { transform: "translateX(-100vh)" },
+          "100%": { transform: "translateX(0)" },
         },
       },
     },


### PR DESCRIPTION
Asana Task: [Create sidebar](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210172293290202?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Added `<SideBar />` component.
added a new `<LadderPage />` wrapper component that will be in charge of rendering `<Ladders />` and `<SideBar />`.

OUTSTANDING ITEMS:
- the ticket specifies putting this feature behind a keycloak group. currently I have Orbit checking for the group `orbit-rl-sidebar`, but if the group ends up being named something different, then `js/groups.ts` must be updated to reflect that. `fake_oidcc` is also updated with this group as an option for local testing. If the user has the group, then they can click on train pills to make the sidebar "slide-in". If they do not have the user group, then clicking on the train pills does nothing (they still look clickable though because they're `<button />`'s... is there a better way to do this?)
- ^ related to above, need to coordinate with infra/product on Red Line staff that should be included in this initial test group.
- there are still some browser window sizes that throws off the sidebar "pushing" the ladders to the right in order to make space for itself. It works for the most part in a lot of cases, but in the screenrecording below, ~1:05 I try to demonstrate that depending on the size of the browser window (and possibly also the scroll position?) the sidebar will simply slide-out on top of the ladder, instead of "pushing" the ladder and making space. I had a hard time playing around in Tailwind trying to get this to work as robustly as I wanted so this probably could use a small rework. Take a look at 

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
