### PR TITLE
feat(ocs): match trips based on TSCH_ASN and "next" trip UIDs

### DIFF
--- a/lib/orbit/ocs/repo/entities.ex
+++ b/lib/orbit/ocs/repo/entities.ex
@@ -81,7 +81,7 @@ defmodule Orbit.Ocs.Entities do
       }
       |> Train.changeset()
       |> Repo.insert(
-        on_conflict: {:replace, [:cars]},
+        on_conflict: {:replace, [:cars, :updated_at]},
         conflict_target: [:service_date, :uid, :rail_line]
       )
 
@@ -124,7 +124,8 @@ defmodule Orbit.Ocs.Entities do
          [
            :destination_station,
            :route,
-           :scheduled_arrival
+           :scheduled_arrival,
+           :updated_at
          ]},
       conflict_target: [:service_date, :rail_line, :uid]
     )
@@ -140,7 +141,7 @@ defmodule Orbit.Ocs.Entities do
     }
     |> Trip.changeset()
     |> Repo.insert(
-      on_conflict: {:replace, [:deleted]},
+      on_conflict: {:replace, [:deleted, :updated_at]},
       conflict_target: [:service_date, :rail_line, :uid]
     )
     |> List.wrap()
@@ -157,7 +158,7 @@ defmodule Orbit.Ocs.Entities do
     }
     |> Trip.changeset()
     |> Repo.insert(
-      on_conflict: {:replace, [:prev_uid, :next_uid]},
+      on_conflict: {:replace, [:prev_uid, :next_uid, :updated_at]},
       conflict_target: [:service_date, :rail_line, :uid]
     )
     |> List.wrap()
@@ -172,7 +173,7 @@ defmodule Orbit.Ocs.Entities do
     }
     |> Trip.changeset()
     |> Repo.insert(
-      on_conflict: {:replace, [:offset]},
+      on_conflict: {:replace, [:offset, :updated_at]},
       conflict_target: [:service_date, :rail_line, :uid]
     )
     |> List.wrap()
@@ -199,7 +200,7 @@ defmodule Orbit.Ocs.Entities do
       }
       |> Train.changeset()
       |> Repo.insert(
-        on_conflict: {:replace, [:cars, :car_tags, :tags]},
+        on_conflict: {:replace, [:cars, :car_tags, :tags, :updated_at]},
         conflict_target: [:service_date, :uid, :rail_line]
       )
 
@@ -221,7 +222,7 @@ defmodule Orbit.Ocs.Entities do
     }
     |> Trip.changeset()
     |> Repo.insert(
-      on_conflict: {:replace, [:train_uid]},
+      on_conflict: {:replace, [:train_uid, :updated_at]},
       conflict_target: [:service_date, :uid, :rail_line]
     )
   end

--- a/lib/orbit/ocs/repo/trip.ex
+++ b/lib/orbit/ocs/repo/trip.ex
@@ -8,6 +8,7 @@ defmodule Orbit.Ocs.Trip do
           service_date: Date.t(),
           uid: String.t(),
           train_uid: String.t() | nil,
+          assigned_at: DateTime.t() | nil,
           prev_uid: String.t() | nil,
           next_uid: String.t() | nil,
           route: String.t() | nil,
@@ -26,6 +27,7 @@ defmodule Orbit.Ocs.Trip do
     field(:service_date, :date)
     field(:uid, :string)
     field(:train_uid, :string)
+    field(:assigned_at, :utc_datetime)
 
     field(:prev_uid, :string)
     field(:next_uid, :string)

--- a/lib/orbit_web/controllers/ocs/trips.html.heex
+++ b/lib/orbit_web/controllers/ocs/trips.html.heex
@@ -7,6 +7,7 @@
     <th>rail_line</th>
     <th>uid</th>
     <th>train_uid</th>
+    <th>assigned_at</th>
     <th>prev_uid</th>
     <th>next_uid</th>
     <th>route</th>
@@ -27,6 +28,7 @@
       <td>{trip.rail_line}</td>
       <td>{trip.uid}</td>
       <td>{trip.train_uid}</td>
+      <td>{trip.assigned_at}</td>
       <td>{trip.prev_uid}</td>
       <td>{trip.next_uid}</td>
       <td>{trip.route}</td>

--- a/lib/realtime/trip_matcher.ex
+++ b/lib/realtime/trip_matcher.ex
@@ -8,8 +8,8 @@ defmodule Realtime.TripMatcher do
   @spec match_trips([VehiclePosition.t()], [TripUpdate.t()], [Trip.t()]) :: [Vehicle.t()]
   def match_trips(vehicle_positions, trip_updates, ocs_trips) do
     ocs_trips_by_uid =
-      Enum.reduce(ocs_trips, %{}, fn trip, map ->
-        Map.put(map, trip.uid, trip)
+      Enum.into(ocs_trips, %{}, fn trip ->
+        {trip.uid, trip}
       end)
 
     Enum.map(vehicle_positions, fn vp ->

--- a/priv/repo/migrations/20250711191108_alter_ocs_trip_assigned_at_column.exs
+++ b/priv/repo/migrations/20250711191108_alter_ocs_trip_assigned_at_column.exs
@@ -1,0 +1,9 @@
+defmodule Orbit.Repo.Migrations.OcsAlterTripAssignedAtColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ocs_trips) do
+      add :assigned_at, :utc_datetime
+    end
+  end
+end

--- a/test/orbit/ocs/repo/entities_test.exs
+++ b/test/orbit/ocs/repo/entities_test.exs
@@ -48,12 +48,12 @@ defmodule Orbit.Ocs.EntitiesTest do
   end
 
   describe("apply_changes") do
-    test "inserts trip for TSCH_NEW" do
+    test "upserts trip for TSCH_NEW" do
       message = %Message.TschNewMessage{
         counter: 111,
         timestamp: @test_datetime,
         transitline: :red,
-        trip_uid: "TRIP_UID_2",
+        trip_uid: "TRIP_UID",
         add_type: "ADD_TYPE",
         trip_type: "TRIP_TYPE",
         sched_dep: @test_datetime,
@@ -70,14 +70,14 @@ defmodule Orbit.Ocs.EntitiesTest do
       queried =
         Repo.get_by!(
           Trip,
-          uid: "TRIP_UID_2",
+          uid: "TRIP_UID",
           service_date: @test_service_date,
           rail_line: :red
         )
 
       assert %Trip{
                service_date: @test_service_date,
-               uid: "TRIP_UID_2",
+               uid: "TRIP_UID",
                train_uid: nil,
                prev_uid: "PREV_TRIP_UID",
                next_uid: "NEXT_TRIP_UID",

--- a/test/orbit/ocs/repo/entities_test.exs
+++ b/test/orbit/ocs/repo/entities_test.exs
@@ -162,6 +162,7 @@ defmodule Orbit.Ocs.EntitiesTest do
                service_date: @test_service_date,
                uid: "TRIP_UID",
                train_uid: "TRAIN_UID_2",
+               assigned_at: @test_datetime_utc,
                rail_line: :red,
                # Check that other fields still exist
                route: "ROUTE"


### PR DESCRIPTION
Asana Task: [Read in the OCS raw messages](https://app.asana.com/1/15492006741476/project/1210239137170761/task/1209929021017070?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->
This change attempts to improve our trip matching logic based on a few assumptions / observations of OCS messages, namely:

1. A `TSCH_ASN` message is a reasonable indicator that a train has been assigned to a "current" trip, as they typically come through shortly before the first `TMOV` of the trip.
    - Exception: It appears to be common in the early morning (~6 am) in cases where a train is being assigned to its first trip of the day, for these messages to come in an hour+ ahead of time (say ~4:45am), but I think in that case Orbit would still want to convey that to users.
    
2. Finding the "next" trips for a train cannot really be done by looking for direct train UID assignment on those trips, as those trips may remain unassigned until right before they begin. A best-guess at this point is to look at the "current" trip's `next_uid` field to follow trips (within a block?). While sometimes a train will not finish out said block (and instead be replaced by another consist), this still seems to be the best guess I can discern for now.

(I will work on posting some Splunk observations in support of these claims.)

To implement these changes:

1. Set an `assigned_at` timestamp on each trip as `TSCH_ASN` is received. This allows the DB to keep track of past assignments but also discern which is the most current.
2. Assign "current" trip as the one with matching train UID and latest value for `assigned_at`.
3. When a "current" trip is found, follow any potential `next_uid` links and provide these as the "next" trips (guarding against cases where a next trip may be assigned to a different train).

TODO in future PRs:

- Make our message handling respect the timestamp of the message as emitted by Trike, to improve accuracy of the `assigned_at` timestamp in cases where messages are delayed, or where old messages are being re-processed.


Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
