### PR TITLE
fix: convert TSCH_DST arrivals to Ecto-safe timestamps

### DIFF
--- a/lib/orbit/ocs/repo/entities.ex
+++ b/lib/orbit/ocs/repo/entities.ex
@@ -103,7 +103,7 @@ defmodule Orbit.Ocs.Entities do
       destination_station: message.dest_sta,
       # TODO: Should we update these if they are nil, or leave the old values?
       route: message.ocs_route_id,
-      scheduled_arrival: message.sched_arr
+      scheduled_arrival: message.sched_arr && Util.Time.to_ecto_utc(message.sched_arr)
     }
     |> Trip.changeset()
     |> Repo.insert(


### PR DESCRIPTION
No Asana Task.

Fix for Sentry Issue: [ORBIT-4K](https://mbtace.sentry.io/issues/6736724172/?environment=staging&notification_uuid=9b60fec5-2bfc-4665-95f6-11a0f8a8c6ba&project=4507425970520064&referrer=assigned_activity-email)

```
:utc_datetime expects the time zone to be "Etc/UTC", got `#DateTime<2025-07-15 12:27:00-04:00 EDT America/New_York>`
```

We convert local timestamps to UTC (and truncate off sub-second precision) to comply with Ecto's `utc_datetime` column type. Unfortunately I forgot to do this for `TSCH_DST` scheduled arrival times.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
