### PR TITLE
feat(ocs): revise message timestamp handling

### DIFF
--- a/lib/orbit/ocs/parser/parser.ex
+++ b/lib/orbit/ocs/parser/parser.ex
@@ -46,7 +46,7 @@ defmodule Orbit.Ocs.Parser do
         ArgumentError -> msg_type
       end
 
-    time = get_time(msg_time, emitted_time)
+    time = Orbit.Ocs.Utilities.Time.interpret_ocs_message_timestamp(msg_time, emitted_time)
     {count, type, time, rest}
   end
 
@@ -61,24 +61,6 @@ defmodule Orbit.Ocs.Parser do
 
       {_count, msg_type, _timestamp, _args} ->
         {:error, "Message type #{msg_type} did not match any expected message"}
-    end
-  end
-
-  # The message time contained within an OCS message does not specify the full date, but only
-  # the hour, minute, and second relative to the date that the message was emitted. Therefore
-  # we need to infer the full timestamp by considering the service date on which the message
-  # was originally emitted.
-  @spec get_time(String.t(), DateTime.t()) :: DateTime.t()
-  defp get_time(msg_time, emitted_datetime) do
-    # allow msg_time to be up to one hour in the future from the time it was emitted;
-    # otherwise assume it is from the day before
-    time = Timex.parse!(msg_time, "{h24}:{m}:{s}")
-    dt = Timex.set(emitted_datetime, hour: time.hour, minute: time.minute, second: time.second)
-
-    if Timex.before?(dt, Timex.shift(emitted_datetime, hours: 1)) do
-      dt
-    else
-      Timex.shift(dt, days: -1)
     end
   end
 

--- a/lib/orbit/ocs/utilities/time.ex
+++ b/lib/orbit/ocs/utilities/time.ex
@@ -24,7 +24,8 @@ defmodule Orbit.Ocs.Utilities.Time do
     # Interpret message time as local time for the same date that the message was emitted.
     [hours, minutes, seconds] = msg_time |> String.split(":") |> Enum.map(&String.to_integer/1)
 
-    emitted_date = DateTime.to_date(emitted_datetime)
+    emitted_datetime_local = DateTime.shift_zone!(emitted_datetime, timezone)
+    emitted_date = DateTime.to_date(emitted_datetime_local)
 
     {dt, same_day?} =
       case DateTime.new(

--- a/lib/orbit/ocs/utilities/time.ex
+++ b/lib/orbit/ocs/utilities/time.ex
@@ -79,14 +79,7 @@ defmodule Orbit.Ocs.Utilities.Time do
 
   @spec closer_datetime(DateTime.t(), DateTime.t(), DateTime.t()) :: DateTime.t()
   defp closer_datetime(earlier, later, datetime) do
-    diff = DateTime.diff(later, earlier, :second)
-    cutoff = DateTime.shift(earlier, second: trunc(diff / 2))
-
-    if DateTime.before?(datetime, cutoff) do
-      earlier
-    else
-      later
-    end
+    Enum.min_by([earlier, later], &abs(DateTime.diff(&1, datetime)))
   end
 
   @service_date_hour_cutoff 2

--- a/test/orbit/ocs/utilities/time_test.exs
+++ b/test/orbit/ocs/utilities/time_test.exs
@@ -1,0 +1,163 @@
+defmodule Orbit.Ocs.Utilities.TimeTests do
+  use ExUnit.Case, async: true
+
+  alias Orbit.Ocs.Utilities.Time, as: OcsTime
+
+  @timezone Application.compile_env(:orbit, :timezone)
+  @test_date ~D[2025-04-08]
+  @test_date_before ~D[2025-04-07]
+  @spring_ahead_date_before ~D[2025-03-08]
+  @spring_ahead_date ~D[2025-03-09]
+  @spring_ahead_date_after ~D[2025-03-10]
+  @fall_back_date_before ~D[2024-11-02]
+  @fall_back_date ~D[2024-11-03]
+  @fall_back_date_after ~D[2024-11-04]
+
+  describe "interpret_ocs_message_timestamp : general cases" do
+    test "it interprets recent timestamps as the current date" do
+      dt_6_00_00 = DateTime.new!(@test_date, ~T[06:00:00], @timezone)
+      dt_5_00_00 = DateTime.new!(@test_date, ~T[05:00:00], @timezone)
+      {:ok, emitted} = dt_6_00_00 |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("05:00:00", emitted)
+      assert result == dt_5_00_00
+    end
+
+    test "it interprets \"future\" timestamps within the next hour as the current date" do
+      dt_6_00_00 = DateTime.new!(@test_date, ~T[06:00:00], @timezone)
+      dt_6_59_59 = DateTime.new!(@test_date, ~T[06:59:59], @timezone)
+      {:ok, emitted} = dt_6_00_00 |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("06:59:59", emitted)
+      assert result == dt_6_59_59
+    end
+
+    test "it interprets \"future\" timestamps at/beyond the next hour as stale, ie belonging to the prior day" do
+      dt_6_00_00 = DateTime.new!(@test_date, ~T[06:00:00], @timezone)
+      dt_7_00_00_day_before = DateTime.new!(@test_date_before, ~T[07:00:00], @timezone)
+      {:ok, emitted} = dt_6_00_00 |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("07:00:00", emitted)
+      assert result == dt_7_00_00_day_before
+    end
+  end
+
+  describe "interpret_ocs_message_timestamp : on spring ahead from EST to EDT" do
+    # OCS Message Timestamps jump from 1:59 to 3:00
+
+    test "it interprets upcoming timestamps (1:59 -> 3:00)" do
+      dt_1_59_59 = DateTime.new!(@spring_ahead_date, ~T[01:59:59], @timezone)
+      dt_3_00_00 = DateTime.new!(@spring_ahead_date, ~T[03:00:00], @timezone)
+
+      # We spring ahead at 2am to 3am, so these times are only 1 second apart
+      assert 1 == DateTime.diff(dt_3_00_00, dt_1_59_59, :second)
+
+      # Based on OCS_Saver logs, OCS starts the new timezone by emitting messages
+      # that are correctly stamped as 03:00:00. By convention from RTR, we
+      # consider message timestamps up to on hour in the future as belonging to
+      # current day.
+      # So at 1:59 AM, a 3:00 AM message is well within the 1-hour cutoff and
+      # should be interpreted as the same day.
+      {:ok, emitted} = dt_1_59_59 |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("03:00:00", emitted)
+      assert result == dt_3_00_00
+    end
+
+    test "it interprets old timestamps from the prior day" do
+      dt_1_59_59 = DateTime.new!(@spring_ahead_date, ~T[01:59:59], @timezone)
+      dt_3_59_59_day_before = DateTime.new!(@spring_ahead_date_before, ~T[03:59:59], @timezone)
+
+      # We spring ahead at 2am to 3am, so these times are 22 hours apart
+      assert 22 == DateTime.diff(dt_1_59_59, dt_3_59_59_day_before, :hour)
+
+      # Based on OCS_Saver logs, OCS starts the new timezone by emitting messages
+      # that are correctly stamped as 03:00:00. By convention from RTR, we
+      # consider message timestamps up to on hour in the future as belonging to
+      # current day.
+      # So at 1:59 AM, a 3:59 message reaches the 1-hour cutoff and should be
+      # interpreted as the previous day.
+      {:ok, emitted} = dt_1_59_59 |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("03:59:59", emitted)
+      assert result == dt_3_59_59_day_before
+    end
+
+    test "it interprets (unexpected) gap timestamps as belonging to the prior day" do
+      dt_1_59_59 = DateTime.new!(@spring_ahead_date, ~T[01:59:59], @timezone)
+      dt_2_00_00_day_before = DateTime.new!(@spring_ahead_date_before, ~T[02:00:00], @timezone)
+
+      # We spring ahead at 2am to 3am, so these times are 24 hours - 1 second apart
+      assert 86_399 == DateTime.diff(dt_1_59_59, dt_2_00_00_day_before, :second)
+
+      {:ok, emitted} = dt_1_59_59 |> DateTime.shift_zone("Etc/UTC")
+
+      # If we interpret "02:00:00" as "2am" local time of the current day, that corresponds
+      # to a time that does not exist, ie falls in the 1:59:59 -> 3:00:00 gap. Since OCS is
+      # not expected to produce gap timestamps, we should interpret it as falling on the
+      # prior day.
+      result = OcsTime.interpret_ocs_message_timestamp("02:00:00", emitted)
+      assert result == dt_2_00_00_day_before
+    end
+
+    test "on day after spring-ahead, safely interprets stale timestamps" do
+      dt_midnight_day_after = DateTime.new!(@spring_ahead_date_after, ~T[00:00:00], @timezone)
+      dt_3_00_00 = DateTime.new!(@spring_ahead_date, ~T[03:00:00], @timezone)
+
+      {:ok, emitted} = dt_midnight_day_after |> DateTime.shift_zone("Etc/UTC")
+
+      # 2:30 am is beyond 1 hour in the future, so should be interpreted as the day prior.
+      # But that makes it a gap timestamp. Should safely parse and (arbitrarily)
+      # assume the first legal timestamp after the gap (ie, 3am)
+      result = OcsTime.interpret_ocs_message_timestamp("02:30:00", emitted)
+      assert result == dt_3_00_00
+    end
+  end
+
+  describe "interpret_ocs_message_timestamp : on fall back from EDT to EST" do
+    # OCS Message Timestamps go from 1:59 back to 1:00
+
+    test "it chooses the earlier of ambiguous timestamps when closer to the earlier time" do
+      {:ambiguous, dt_1_29_59_earlier, _later} =
+        DateTime.new(@fall_back_date, ~T[01:29:59], @timezone)
+
+      {:ambiguous, dt_1_00_00_earlier, _later} =
+        DateTime.new(@fall_back_date, ~T[01:00:00], @timezone)
+
+      {:ok, emitted} = dt_1_29_59_earlier |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("01:00:00", emitted)
+      assert result == dt_1_00_00_earlier
+    end
+
+    test "it chooses the later of ambiguous timestamps when closer to the later time" do
+      {:ambiguous, dt_1_30_00_earlier, _later} =
+        DateTime.new(@fall_back_date, ~T[01:30:00], @timezone)
+
+      {:ambiguous, _earlier, dt_1_00_00_later} =
+        DateTime.new(@fall_back_date, ~T[01:00:00], @timezone)
+
+      {:ok, emitted} = dt_1_30_00_earlier |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("01:00:00", emitted)
+      assert result == dt_1_00_00_later
+    end
+
+    test "it still interprets stale timestamps from the prior day" do
+      dt_midnight = DateTime.new!(@fall_back_date, ~T[00:00:00], @timezone)
+      dt_1_00_00_day_before = DateTime.new!(@fall_back_date_before, ~T[01:00:00], @timezone)
+
+      {:ok, emitted} = dt_midnight |> DateTime.shift_zone("Etc/UTC")
+      result = OcsTime.interpret_ocs_message_timestamp("01:00:00", emitted)
+      assert result == dt_1_00_00_day_before
+    end
+
+    test "on day after fallback, safely interprets stale timestamps" do
+      dt_midnight_day_after = DateTime.new!(@fall_back_date_after, ~T[00:00:00], @timezone)
+
+      {:ambiguous, _earlier, dt_1_30_00_later} =
+        DateTime.new(@fall_back_date, ~T[01:30:00], @timezone)
+
+      {:ok, emitted} = dt_midnight_day_after |> DateTime.shift_zone("Etc/UTC")
+
+      # 1:30 am is beyond 1 hour in the future, so should be interpreted as the day prior.
+      # But that makes it an ambiguous timestamp. Should safely parse and (arbitrarily)
+      # assume the later timestamp.
+      result = OcsTime.interpret_ocs_message_timestamp("01:30:00", emitted)
+      assert result == dt_1_30_00_later
+    end
+  end
+end

--- a/test/orbit/ocs/utilities/time_test.exs
+++ b/test/orbit/ocs/utilities/time_test.exs
@@ -141,13 +141,13 @@ defmodule Orbit.Ocs.Utilities.TimeTests do
     end
 
     test "it chooses the later of ambiguous timestamps when closer to the later time" do
-      {:ambiguous, dt_1_30_00_earlier, _later} =
-        DateTime.new(@fall_back_date, ~T[01:30:00], @timezone)
+      {:ambiguous, dt_1_30_01_earlier, _later} =
+        DateTime.new(@fall_back_date, ~T[01:30:01], @timezone)
 
       {:ambiguous, _earlier, dt_1_00_00_later} =
         DateTime.new(@fall_back_date, ~T[01:00:00], @timezone)
 
-      {:ok, emitted} = dt_1_30_00_earlier |> DateTime.shift_zone("Etc/UTC")
+      {:ok, emitted} = dt_1_30_01_earlier |> DateTime.shift_zone("Etc/UTC")
       result = OcsTime.interpret_ocs_message_timestamp("01:00:00", emitted)
       assert result == dt_1_00_00_later
     end


### PR DESCRIPTION
Continued work on Asana Task: [Read in the OCS raw messages](https://app.asana.com/1/15492006741476/project/1210239137170761/task/1209929021017070?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

For context: OCS messages contain an `hh:mm:ss` timestamp that indicates when the relevant change occurred in OCS. Since these timestamps are not fully specified, in that they don't tell you the actual _date_, the parser must infer that.

Two changes here:

- The parser would previously infer the relevant date based on _current time_. If we are receiving messages in realtime, this is reasonable, but not if Orbit is processing old messages from Kinesis. It makes more sense to use the timestamp that the CloudEvent was emitted by Trike, since that's a more accurate indicator of when OCS actually emitted this change.

- I've taken a stab at revising how the timestamps are parsed and reasoned about. Some details:
  - RTR considers any time >= 1 hour in the future to be stale and assumes instead that the time corresponds to yesterday. I've kept this logic in place, albeit now relative to event emission time, not current time at parsing. (Keep in mind that currently we don't expect to see messages older than 24 hours, since that's how long Kinesis keeps them. Maybe it's possible for OCS to _emit_ very old messages, but hopefully not.)
  - There are some (maybe) nitpicky scenarios where I think the original parsing code introduces small errors during daylight savings time. This mostly would occur for stale message processing, and maybe isn't super important, but I've tried to fix it anyway.
  - I've added tests, particularly around D.S.T. change boundaries.
  - I've removed our use of Timex, at least in this function, as I believe Elixir's recent updates to the native `DateTime` now provide what we need.

Still TODO in future work:

- I have not yet changed how *schedule times* within a message are interpreted relative to the service date. I may revise that or at least add more tests.
- We may want to combine some of our time utils into a single module (although maybe not when you consider that we might extract the OCS-specific stuff into to a library or lift it upstream into Trike.)

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
