### PR TITLE
feat: add VehicleEventDetector

### DIFF
--- a/lib/orbit/application.ex
+++ b/lib/orbit/application.ex
@@ -58,7 +58,8 @@ defmodule Orbit.Application do
                    }
                  ]}
             },
-            Realtime.TripMatcherServer
+            Realtime.TripMatcherServer,
+            Realtime.VehicleEventDetector
           ]
         else
           []

--- a/lib/orbit/rail_line.ex
+++ b/lib/orbit/rail_line.ex
@@ -31,4 +31,7 @@ defmodule Orbit.RailLine do
       _ -> :none
     end
   end
+
+  @spec from_route_id(Realtime.Data.route_id()) :: t()
+  def from_route_id(:Red), do: :red
 end

--- a/lib/realtime/data/stations.ex
+++ b/lib/realtime/data/stations.ex
@@ -56,4 +56,58 @@ defmodule Realtime.Data.Stations do
       "Braintree-02" => "place-brntn"
     }
   end
+
+  @spec next_stations(String.t() | nil, integer()) :: [String.t()]
+  def next_stations(station_id, direction) do
+    case {station_id, direction} do
+      # Southbound
+
+      {"place-alfcl", 0} -> ["place-davis"]
+      {"place-davis", 0} -> ["place-portr"]
+      {"place-portr", 0} -> ["place-harsq"]
+      {"place-harsq", 0} -> ["place-cntsq"]
+      {"place-cntsq", 0} -> ["place-knncl"]
+      {"place-knncl", 0} -> ["place-chmnl"]
+      {"place-chmnl", 0} -> ["place-pktrm"]
+      {"place-pktrm", 0} -> ["place-dwnxg"]
+      {"place-dwnxg", 0} -> ["place-sstat"]
+      {"place-sstat", 0} -> ["place-brdwy"]
+      {"place-brdwy", 0} -> ["place-andrw"]
+      {"place-andrw", 0} -> ["place-jfk"]
+      {"place-jfk", 0} -> ["place-shmnl", "place-nqncy"]
+      {"place-shmnl", 0} -> ["place-fldcr"]
+      {"place-fldcr", 0} -> ["place-smmnl"]
+      {"place-smmnl", 0} -> ["place-asmnl"]
+      {"place-asmnl", 0} -> []
+      {"place-nqncy", 0} -> ["place-wlsta"]
+      {"place-wlsta", 0} -> ["place-qnctr"]
+      {"place-qnctr", 0} -> ["place-qamnl"]
+      {"place-qamnl", 0} -> ["place-brntn"]
+      {"place-brntn", 0} -> []
+      # Northbound
+      {"place-alfcl", 1} -> []
+      {"place-davis", 1} -> ["place-alfcl"]
+      {"place-portr", 1} -> ["place-davis"]
+      {"place-harsq", 1} -> ["place-portr"]
+      {"place-cntsq", 1} -> ["place-harsq"]
+      {"place-knncl", 1} -> ["place-cntsq"]
+      {"place-chmnl", 1} -> ["place-knncl"]
+      {"place-pktrm", 1} -> ["place-chmnl"]
+      {"place-dwnxg", 1} -> ["place-pktrm"]
+      {"place-sstat", 1} -> ["place-dwnxg"]
+      {"place-brdwy", 1} -> ["place-sstat"]
+      {"place-andrw", 1} -> ["place-brdwy"]
+      {"place-jfk", 1} -> ["place-andrw"]
+      {"place-shmnl", 1} -> ["place-jfk"]
+      {"place-fldcr", 1} -> ["place-shmnl"]
+      {"place-smmnl", 1} -> ["place-fldcr"]
+      {"place-asmnl", 1} -> ["place-smmnl"]
+      {"place-nqncy", 1} -> ["place-jfk"]
+      {"place-wlsta", 1} -> ["place-qnctr"]
+      {"place-qnctr", 1} -> ["place-qamnl"]
+      {"place-qamnl", 1} -> ["place-brntn"]
+      {"place-brntn", 1} -> ["place-qamnl"]
+      _ -> []
+    end
+  end
 end

--- a/lib/realtime/data/vehicle_event.ex
+++ b/lib/realtime/data/vehicle_event.ex
@@ -1,0 +1,58 @@
+defmodule Realtime.Data.VehicleEvent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Orbit.RailLine
+
+  @type t :: %__MODULE__{
+          service_date: Date.t(),
+          cars: [String.t()],
+          station_id: String.t(),
+          vehicle_id: String.t(),
+          direction_id: integer(),
+          rail_line: RailLine.t(),
+          arrival_departure: :arrival | :departure,
+          timestamp: DateTime.t()
+        }
+
+  schema "vehicle_events" do
+    field(:service_date, :date)
+    field(:rail_line, RailLine)
+    field(:cars, {:array, :string})
+    field(:station_id, :string)
+    field(:vehicle_id, :string)
+    field(:direction_id, :integer)
+    field(:arrival_departure, Ecto.Enum, values: [:arrival, :departure])
+    field(:timestamp, :utc_datetime)
+    timestamps()
+  end
+
+  def changeset(struct, attrs \\ %{}) do
+    struct
+    |> cast(
+      attrs,
+      [
+        :service_date,
+        :rail_line,
+        :cars,
+        :station_id,
+        :vehicle_id,
+        :direction_id,
+        :arrival_departure,
+        :timestamp
+      ]
+    )
+    |> validate_required([
+      :service_date,
+      :rail_line,
+      :cars,
+      :station_id,
+      :vehicle_id,
+      :direction_id,
+      :arrival_departure,
+      :timestamp
+    ])
+    |> validate_inclusion(:direction_id, [0, 1])
+    |> validate_inclusion(:arrival_departure, [:arrival, :departure])
+  end
+end

--- a/lib/realtime/vehicle_event_detector.ex
+++ b/lib/realtime/vehicle_event_detector.ex
@@ -1,0 +1,380 @@
+defmodule Realtime.VehicleEventDetector do
+  @moduledoc """
+  Watches for trains entering and exiting stations
+  and stores them in the vehicle_events table
+  """
+
+  use GenServer
+  alias Orbit.RailLine
+  alias Orbit.Repo
+  alias Realtime.Data.Stations
+  alias Realtime.Data.VehicleEvent
+  alias Realtime.Data.VehiclePosition
+
+  @type vehicle_positions_with_timestamp :: %{
+          timestamp: Util.Time.timestamp(),
+          entities: [Realtime.Data.VehiclePosition.t()]
+        }
+
+  @type state :: %{
+          last_vehicle_positions: vehicle_positions_with_timestamp,
+          subscriptions: MapSet.t(pid())
+        }
+
+  @terminals [
+    {"place-alfcl", 0},
+    {"place-asmnl", 1},
+    {"place-brntn", 1}
+  ]
+
+  defmodule StationEvent do
+    @moduledoc """
+    Describes all the ways to enter or exit a station.
+    A subset of VehicleEvent
+    """
+
+    @type t :: %__MODULE__{
+            station_id: String.t(),
+            direction: integer(),
+            arrival_departure: :arrival | :departure
+          }
+
+    @enforce_keys [
+      :station_id,
+      :direction,
+      :arrival_departure
+    ]
+    defstruct [
+      :station_id,
+      :direction,
+      :arrival_departure
+    ]
+
+    @spec new(String.t(), integer(), :arrival | :departure) :: t
+    def new(station_id, direction, arrival_departure) do
+      %StationEvent{
+        station_id: station_id,
+        direction: direction,
+        arrival_departure: arrival_departure
+      }
+    end
+  end
+
+  # Client functions
+
+  @spec start_link(any()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @spec subscribe(pid()) :: :ok
+  def subscribe(pid) do
+    GenServer.call(__MODULE__, {:subscribe, pid})
+  end
+
+  # GenServer callbacks
+
+  @impl true
+  def init(_args) do
+    current_vehicle_positions =
+      Realtime.PollingServer.subscribe(self(), :vehicle_positions)
+
+    {:ok,
+     %{
+       last_vehicle_positions: current_vehicle_positions,
+       subscriptions: MapSet.new()
+     }}
+  end
+
+  @impl true
+  def handle_info({:new_data, :vehicle_positions, new_vehicle_positions}, state) do
+    new_state = %{state | last_vehicle_positions: new_vehicle_positions}
+
+    new_events =
+      new_vehicle_events(
+        state.last_vehicle_positions,
+        new_vehicle_positions,
+        Util.Time.current_service_date()
+      )
+
+    if new_events != [] do
+      Enum.each(state.subscriptions, fn pid ->
+        send(pid, {:new_data, :vehicle_events, new_events})
+      end)
+
+      new_events
+      |> Enum.map(&VehicleEvent.changeset/1)
+      |> Enum.each(&Repo.insert(&1, log: false))
+    end
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({:DOWN, _monitor_ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | subscriptions: MapSet.delete(state.subscriptions, pid)}}
+  end
+
+  @impl true
+  def handle_call({:subscribe, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, :ok, %{state | subscriptions: MapSet.put(state.subscriptions, pid)}}
+  end
+
+  @spec new_vehicle_events(
+          vehicle_positions_with_timestamp,
+          vehicle_positions_with_timestamp,
+          Date.t()
+        ) :: [VehicleEvent.t()]
+  def new_vehicle_events(%{timestamp: 0, entities: []}, _new_vehicle_positions, _service_date) do
+    # Don't look for changes the first time we get real data
+    []
+  end
+
+  def new_vehicle_events(old_vehicle_positions, new_vehicle_positions, service_date) do
+    # list of {old_vp | nil, new_vp | nil} pairs
+    Util.List.zip_by(old_vehicle_positions.entities, new_vehicle_positions.entities, fn vp ->
+      MapSet.new(vp.cars)
+    end)
+    |> Enum.flat_map(&vehicle_events_for_one_train(&1, service_date))
+  end
+
+  @spec vehicle_events_for_one_train({VehiclePosition.t(), VehiclePosition.t()}, Date.t()) :: [
+          StationEvent.t()
+        ]
+  defp vehicle_events_for_one_train({old_vp, new_vp}, service_date) do
+    station_events = station_events_for_one_train({old_vp, new_vp})
+
+    Enum.map(station_events, fn station_event ->
+      %VehicleEvent{
+        service_date: service_date,
+        cars: new_vp.cars,
+        station_id: station_event.station_id,
+        vehicle_id: new_vp.vehicle_id,
+        rail_line: RailLine.from_route_id(new_vp.route_id),
+        direction_id: station_event.direction,
+        arrival_departure: station_event.arrival_departure,
+        timestamp: new_vp.timestamp
+      }
+    end)
+  end
+
+  @doc """
+  In order to reduce duplication among the dozens of different cases for how a train might move,
+  This uses StationEvent to only return the information that's different in each case.
+  The rest of the fields, like cars, are filled in later to make a full VehicleEvent.
+  """
+  @spec station_events_for_one_train({VehiclePosition.t() | nil, VehiclePosition.t() | nil}) :: [
+          StationEvent.t()
+        ]
+  def station_events_for_one_train({
+        %VehiclePosition{} = _old_vp,
+        nil
+      }) do
+    # Train disappeared
+    []
+  end
+
+  def station_events_for_one_train({
+        nil,
+        %VehiclePosition{} = new_vp
+      }) do
+    # New train appeared
+    # If a train appears while still at a terminal, we'll record the departure later when it leaves
+    # If a train appears far from a terminal, we don't know how to reconstruct its history
+    # In both of those cases, we don't want to record any events.
+    # But sometimes trains won't appear until just after leaving their pullout location
+    # In that case, we can record their recent departure from the pullout.
+    Enum.flat_map(@terminals, fn {pullout, departure_direction} ->
+      if departure_direction != nil && new_vp.direction == departure_direction &&
+           new_vp.station_id in Stations.next_stations(pullout, departure_direction) do
+        case new_vp.current_status do
+          :STOPPED_AT ->
+            # The train wasn't registered until it made it to the next station.
+            [
+              StationEvent.new(pullout, departure_direction, :departure),
+              StationEvent.new(new_vp.station_id, departure_direction, :arrival)
+            ]
+
+          _ ->
+            # Noticed before the train got to the next station
+            [
+              StationEvent.new(pullout, departure_direction, :departure)
+            ]
+        end
+      else
+        []
+      end
+    end)
+  end
+
+  def station_events_for_one_train({
+        %VehiclePosition{direction: old_direction} = old_vp,
+        %VehiclePosition{direction: new_direction} = new_vp
+      })
+      when old_direction == new_direction do
+    # Train is still travelling in the same direction
+    direction = new_vp.direction
+
+    cond do
+      new_vp.station_id == old_vp.station_id ->
+        station = new_vp.station_id
+
+        case {old_vp.current_status, new_vp.current_status} do
+          {:STOPPED_AT, :STOPPED_AT} ->
+            # Still stopped in station. No movement
+            []
+
+          {:STOPPED_AT, _} ->
+            # Moved backwards out of a station?
+            []
+
+          {_, :STOPPED_AT} ->
+            # Entered a station
+            [
+              StationEvent.new(station, direction, :arrival)
+            ]
+
+          {_, _} ->
+            # Moved but didn't reach the station yet.
+            []
+        end
+
+      new_vp.station_id in Stations.next_stations(old_vp.station_id, direction) ->
+        case {old_vp.current_status, new_vp.current_status} do
+          {:STOPPED_AT, :STOPPED_AT} ->
+            # Jumped from one station to the next in one step
+            [
+              StationEvent.new(old_vp.station_id, direction, :departure),
+              StationEvent.new(new_vp.station_id, direction, :arrival)
+            ]
+
+          {:STOPPED_AT, _} ->
+            # Left the first station, now on its way to the next
+            [
+              StationEvent.new(old_vp.station_id, direction, :departure)
+            ]
+
+          {_, :STOPPED_AT} ->
+            # Jumped into, out of, and into the next station
+            [
+              StationEvent.new(old_vp.station_id, direction, :arrival),
+              StationEvent.new(old_vp.station_id, direction, :departure),
+              StationEvent.new(new_vp.station_id, direction, :arrival)
+            ]
+
+          {_, _} ->
+            # Jumped over a station
+            [
+              StationEvent.new(old_vp.station_id, direction, :arrival),
+              StationEvent.new(old_vp.station_id, direction, :departure)
+            ]
+        end
+
+      true ->
+        # Jumped to a far away station. Probably a data problem.
+        []
+    end
+  end
+
+  def station_events_for_one_train({
+        %VehiclePosition{direction: old_direction} = old_vp,
+        %VehiclePosition{direction: new_direction} = new_vp
+      })
+      when old_direction != new_direction do
+    # Train turned around
+    cond do
+      new_vp.station_id == old_vp.station_id ->
+        case {old_vp.current_status, new_vp.current_status} do
+          {:STOPPED_AT, :STOPPED_AT} ->
+            # Turned around in the station.
+            []
+
+          {:STOPPED_AT, _} ->
+            # Left the station, then turned around before reaching the next.
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :departure)
+            ]
+
+          {_, :STOPPED_AT} ->
+            # Entered the station, then turned around.
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :arrival)
+            ]
+
+          {_, _} ->
+            # Jumped over the station, then turned around
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :arrival),
+              StationEvent.new(old_vp.station_id, old_vp.direction, :departure)
+            ]
+        end
+
+      new_vp.station_id in Stations.next_stations(old_vp.station_id, old_vp.direction) ->
+        # Went forward before turning around
+        case {old_vp.current_status, new_vp.current_status} do
+          {:STOPPED_AT, :STOPPED_AT} ->
+            # Jumped from one station to the next, then turned around
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :departure),
+              StationEvent.new(new_vp.station_id, old_vp.direction, :arrival)
+            ]
+
+          {:STOPPED_AT, _} ->
+            # Jumped out of a station, into the next, then past it, then turned around
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :departure),
+              StationEvent.new(new_vp.station_id, old_vp.direction, :arrival),
+              StationEvent.new(new_vp.station_id, old_vp.direction, :departure)
+            ]
+
+          {_, :STOPPED_AT} ->
+            # Jumped through a station, into the next, then turned around
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :arrival),
+              StationEvent.new(old_vp.station_id, old_vp.direction, :departure),
+              StationEvent.new(new_vp.station_id, old_vp.direction, :arrival)
+            ]
+
+          {_, _} ->
+            # Jumped through both stations, then turned around
+            [
+              StationEvent.new(old_vp.station_id, old_vp.direction, :arrival),
+              StationEvent.new(old_vp.station_id, old_vp.direction, :departure),
+              StationEvent.new(new_vp.station_id, old_vp.direction, :arrival),
+              StationEvent.new(new_vp.station_id, old_vp.direction, :departure)
+            ]
+        end
+
+      new_vp.station_id in Stations.next_stations(old_vp.station_id, new_vp.direction) ->
+        # Turned around, then moved.
+        case {old_vp.current_status, new_vp.current_status} do
+          {:STOPPED_AT, :STOPPED_AT} ->
+            # Turned around, then jumped into the next station
+            [
+              StationEvent.new(old_vp.station_id, new_vp.direction, :departure),
+              StationEvent.new(new_vp.station_id, new_vp.direction, :arrival)
+            ]
+
+          {:STOPPED_AT, _} ->
+            # Turned around, then left the station, now on its way to the next.
+            [
+              StationEvent.new(old_vp.station_id, new_vp.direction, :departure)
+            ]
+
+          {_, :STOPPED_AT} ->
+            # Turned around between stations, then entered the next station in the new direction
+            [
+              StationEvent.new(new_vp.station_id, new_vp.direction, :arrival)
+            ]
+
+          {_, _} ->
+            # Turned around, but hasn't reached the next station yet.
+            []
+        end
+
+      true ->
+        # Jumped to a far away station. Probably a data problem.
+        []
+    end
+  end
+end

--- a/lib/realtime/vehicle_event_detector.ex
+++ b/lib/realtime/vehicle_event_detector.ex
@@ -138,7 +138,10 @@ defmodule Realtime.VehicleEventDetector do
     |> Enum.flat_map(&vehicle_events_for_one_train(&1, service_date))
   end
 
-  @spec vehicle_events_for_one_train({VehiclePosition.t(), VehiclePosition.t()}, Date.t()) :: [
+  @spec vehicle_events_for_one_train(
+          {VehiclePosition.t() | nil, VehiclePosition.t() | nil},
+          Date.t()
+        ) :: [
           StationEvent.t()
         ]
   defp vehicle_events_for_one_train({old_vp, new_vp}, service_date) do

--- a/lib/util/list.ex
+++ b/lib/util/list.ex
@@ -1,0 +1,43 @@
+defmodule Util.List do
+  @doc """
+  Like Enum.group_by, but returns a list of tuples instead of a map to preserve the order
+  Similar to Enum.uniq_by, the order is based on the first appearance
+
+      iex> Util.List.group_by_ordered(~w{ant buffalo cat dingo}, &String.length/1)
+      [{3, ["ant", "cat"]}, {7, ["buffalo"]}, {5, ["dingo"]}]
+  """
+  @spec group_by_ordered([elem], (elem -> key)) :: [{key, elem}] when elem: term(), key: term()
+  def group_by_ordered(list, key_fun) do
+    list
+    |> Enum.with_index()
+    |> Enum.group_by(fn {elem, _index} -> key_fun.(elem) end)
+    |> Enum.map(fn {key, values} ->
+      [{_, index} | _] = values
+      values = Enum.map(values, fn {value, _index} -> value end)
+      {index, key, values}
+    end)
+    |> Enum.sort_by(fn {index, _, _} -> index end)
+    |> Enum.map(fn {_index, key, values} -> {key, values} end)
+  end
+
+  @doc """
+  Assumes each key only appears once per input, or else duplicate elements will be dropped.
+  Output is unordered.
+
+  Used for diffing.
+
+      iex> Util.List.zip_by([{:a, 1}, {:b, 2}], [{:b, 20}, {:c, 30}], fn {k, _} -> k end) |> Enum.sort()
+      [{nil, {:c, 30}}, {{:a, 1}, nil}, {{:b, 2}, {:b, 20}}]
+  """
+  @spec zip_by([elem], [elem], (elem -> key)) :: [{{elem | nil}, {elem | nil}}]
+        when elem: term(), key: term()
+  def zip_by(list_a, list_b, key_fun) do
+    a_map = Map.new(list_a, fn elem -> {key_fun.(elem), {elem, nil}} end)
+    b_map = Map.new(list_b, fn elem -> {key_fun.(elem), {nil, elem}} end)
+
+    merged_map =
+      Map.merge(a_map, b_map, fn _k, {a_elem, nil}, {nil, b_elem} -> {a_elem, b_elem} end)
+
+    Map.values(merged_map)
+  end
+end

--- a/priv/repo/migrations/20250717170938_vehicle_events.exs
+++ b/priv/repo/migrations/20250717170938_vehicle_events.exs
@@ -1,0 +1,24 @@
+defmodule Orbit.Repo.Migrations.VehicleEvents do
+  use Ecto.Migration
+
+  def change do
+    create_query = "CREATE TYPE arrival_departure AS ENUM ('arrival', 'departure')"
+    drop_query = "DROP TYPE arrival_departure"
+    execute(create_query, drop_query)
+
+    create table(:vehicle_events) do
+      add(:service_date, :date, null: false)
+      add(:cars, :jsonb, null: false)
+      add(:station_id, :string, null: false)
+      add(:vehicle_id, :string, null: false)
+      add(:direction_id, :integer, null: false)
+      add(:rail_line, :rail_line, null: false)
+      add(:arrival_departure, :arrival_departure, null: false)
+      add(:timestamp, :utc_datetime, null: false)
+
+      timestamps()
+    end
+
+    create index(:vehicle_events, [:service_date, :station_id])
+  end
+end

--- a/test/realtime/vehicle_event_detector_test.exs
+++ b/test/realtime/vehicle_event_detector_test.exs
@@ -106,7 +106,7 @@ defmodule Realtime.VehicleEventDetectorTest do
       new_vehicle_positions = %{
         timestamp: 200,
         entities: [
-          # Train didn't move, should not make a new departure event at Riverside
+          # Train didn't move, should not make a new departure event at Shawmut
           build(:vehicle_position, %{
             route_id: :Red,
             direction: 1,

--- a/test/realtime/vehicle_event_detector_test.exs
+++ b/test/realtime/vehicle_event_detector_test.exs
@@ -1,0 +1,770 @@
+defmodule Realtime.VehicleEventDetectorTest do
+  use ExUnit.Case, async: true
+
+  import Orbit.Factory
+
+  alias Realtime.Data.VehicleEvent
+  alias Realtime.VehicleEventDetector
+  alias Realtime.VehicleEventDetector.StationEvent
+
+  @service_date ~D[2025-07-17]
+
+  describe "new_vehicle_events" do
+    test "gets event from changed vp but not new or removed vps" do
+      old_vehicle_positions = %{
+        timestamp: 100,
+        entities: [
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1733", "1732", "1737", "1736", "1741", "1740"],
+            # Broadway
+            station_id: "place-brdwy",
+            current_status: :IN_TRANSIT_TO,
+            timestamp: 70
+          }),
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1862", "1863", "1850", "1851", "1843", "1842"],
+            # South Station
+            station_id: "place-sstat",
+            current_status: :IN_TRANSIT_TO,
+            timestamp: 80
+          })
+        ]
+      }
+
+      new_vehicle_positions = %{
+        timestamp: 200,
+        entities: [
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1862", "1863", "1850", "1851", "1843", "1842"],
+            # South Station
+            station_id: "place-sstat",
+            current_status: :STOPPED_AT,
+            timestamp: 180
+          }),
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["3805", "3806"],
+            # Downtown Crossing
+            station_id: "place-dwnxg",
+            current_status: :IN_TRANSIT_TO,
+            timestamp: 190
+          })
+        ]
+      }
+
+      assert [
+               %VehicleEvent{
+                 service_date: @service_date,
+                 cars: ["1862", "1863", "1850", "1851", "1843", "1842"],
+                 # South Station
+                 station_id: "place-sstat",
+                 rail_line: :red,
+                 direction_id: 1,
+                 arrival_departure: :arrival,
+                 timestamp: 180
+               }
+             ] =
+               VehicleEventDetector.new_vehicle_events(
+                 old_vehicle_positions,
+                 new_vehicle_positions,
+                 @service_date
+               )
+    end
+
+    test "reversed car numbers are treated as the same train" do
+      old_vehicle_positions = %{
+        timestamp: 100,
+        entities: [
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1733", "1732", "1737", "1736", "1741", "1740"],
+            # Shawmut
+            station_id: "place-smmnl",
+            current_status: :IN_TRANSIT_TO,
+            timestamp: 70
+          }),
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1862", "1863", "1850", "1851", "1843", "1842"],
+            # South Station
+            station_id: "place-sstat",
+            current_status: :IN_TRANSIT_TO,
+            timestamp: 80
+          })
+        ]
+      }
+
+      new_vehicle_positions = %{
+        timestamp: 200,
+        entities: [
+          # Train didn't move, should not make a new departure event at Riverside
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1740", "1741", "1736", "1737", "1732", "1733"],
+            # Shawmut
+            station_id: "place-smmnl",
+            current_status: :IN_TRANSIT_TO,
+            timestamp: 170
+          }),
+          # Train did move, should make a new event at South Station
+          build(:vehicle_position, %{
+            route_id: :Red,
+            direction: 1,
+            cars: ["1842", "1843", "1851", "1850", "1863", "1862"],
+            # South Station
+            station_id: "place-sstat",
+            current_status: :STOPPED_AT,
+            timestamp: 180
+          })
+        ]
+      }
+
+      assert [
+               %VehicleEvent{
+                 service_date: @service_date,
+                 cars: ["1842", "1843", "1851", "1850", "1863", "1862"],
+                 # South Station
+                 station_id: "place-sstat",
+                 rail_line: :red,
+                 direction_id: 1,
+                 arrival_departure: :arrival,
+                 timestamp: 180
+               }
+             ] =
+               VehicleEventDetector.new_vehicle_events(
+                 old_vehicle_positions,
+                 new_vehicle_positions,
+                 @service_date
+               )
+    end
+  end
+
+  describe "VehicleEventDetector.station_events_for_one_train" do
+    test "records departure from pullout if the train appears just after leaving" do
+      assert [
+               %StationEvent{
+                 # South Station
+                 station_id: "place-asmnl",
+                 direction: 1,
+                 arrival_departure: :departure
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 nil,
+                 build(:vehicle_position, %{
+                   route_id: :Red,
+                   station_id: "place-smmnl",
+                   direction: 1,
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event for recently appeared train that hasn't just left a terminal" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 nil,
+                 build(:vehicle_position, %{
+                   station_id: "place-sstat",
+                   direction: 1,
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 })
+               })
+    end
+
+    test "no event for disappeared train" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 }),
+                 nil
+               })
+    end
+
+    test "new arrival for train pulling into station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "new departure for train pulling out of station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-dwnxg",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event for stopped train in station" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event for stopped train between stations" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event for train moving on track between stations" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "arrival and departure for train jumping through station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               },
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-dwnxg",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "departure and arrival for train jumping from one station to the next" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               },
+               %StationEvent{
+                 station_id: "place-dwnxg",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-dwnxg",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event if jumping to a station that's not immediately next" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   # Park Street
+                   station_id: "place-pktrm",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "new event even if train changes route id" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   route_id: :Red,
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   route_id: :Red,
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event if train goes from in a station to before that station" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "treats IN_TRANSIT_TO and INCOMING_AT the same" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :INCOMING_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event for train switching direction within station" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event if switching direction and jumping to a station that's not adjacent" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-pktrm",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event if switching direction at a station that's not adjacent" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-pktrm",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "departure and arrival in new direction when jumping to previous station in reverse direction" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 0,
+                 arrival_departure: :departure
+               },
+               %StationEvent{
+                 station_id: "place-brdwy",
+                 direction: 0,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-brdwy",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "departure in new direction when reversing direction while leaving a station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 0,
+                 arrival_departure: :departure
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-brdwy",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "departure in old direction when turning around after leaving the station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "departure and arrival in old direction when jumping to next station, then turning around" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               },
+               %StationEvent{
+                 station_id: "place-dwnxg",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-dwnxg",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "arrival in new direction when turning around and entering previous station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-brdwy",
+                 direction: 0,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-brdwy",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "no event when turning around between stations" do
+      assert [] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-brdwy",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "arrival in old direction when turning around after entering station" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-sstat",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "arrival and departure in old direction when jumping over a station then turning around" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               },
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "arrival, departure, and arrival when jumping over a station into the next one" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               },
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               },
+               %StationEvent{
+                 station_id: "place-dwnxg",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-dwnxg",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+
+    test "arrival, departure, and arrival when jumping over a station into the next one and turning around" do
+      assert [
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :arrival
+               },
+               %StationEvent{
+                 station_id: "place-sstat",
+                 direction: 1,
+                 arrival_departure: :departure
+               },
+               %StationEvent{
+                 station_id: "place-dwnxg",
+                 direction: 1,
+                 arrival_departure: :arrival
+               }
+             ] ==
+               VehicleEventDetector.station_events_for_one_train({
+                 build(:vehicle_position, %{
+                   direction: 1,
+                   station_id: "place-sstat",
+                   current_status: :IN_TRANSIT_TO,
+                   timestamp: 70
+                 }),
+                 build(:vehicle_position, %{
+                   direction: 0,
+                   station_id: "place-dwnxg",
+                   current_status: :STOPPED_AT,
+                   timestamp: 170
+                 })
+               })
+    end
+  end
+end

--- a/test/util/list_test.exs
+++ b/test/util/list_test.exs
@@ -1,0 +1,4 @@
+defmodule Util.ListTest do
+  use ExUnit.Case, async: true
+  doctest Util.List
+end


### PR DESCRIPTION
Asana Task: [Sidebar: actual departure (track departures automatically)](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1209646113903412)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

This PR:
- Brings a heavy rail version of VehicleEventDetector over to Orbit
- ⚠️ Does not yet record or facilitate recording `actual_departure` anywhere. That's tomorrow!

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
