### PR TITLE
feat(ocs): ignore extra fields at end of TSCH messages

### DIFF
--- a/lib/orbit/ocs/parser/tsch_message.ex
+++ b/lib/orbit/ocs/parser/tsch_message.ex
@@ -61,7 +61,7 @@ defmodule Orbit.Ocs.Parser.TschMessage do
   defp parse_sub_type(message, emitted_time)
 
   defp parse_sub_type(
-         {count, time, transitline, ["CON", trip_uid, train_consist, train_uid]},
+         {count, time, transitline, ["CON", trip_uid, train_consist, train_uid | _extra]},
          _emitted_time
        ) do
     con =
@@ -93,6 +93,7 @@ defmodule Orbit.Ocs.Parser.TschMessage do
             dest_sta,
             prev_trip_uid,
             next_trip_uid
+            | _extra
           ]},
          emitted_time
        ) do
@@ -126,7 +127,10 @@ defmodule Orbit.Ocs.Parser.TschMessage do
     }
   end
 
-  defp parse_sub_type({count, time, transitline, ["ASN", train_uid, trip_uid]}, _emitted_time) do
+  defp parse_sub_type(
+         {count, time, transitline, ["ASN", train_uid, trip_uid | _extra]},
+         _emitted_time
+       ) do
     %Orbit.Ocs.Message.TschAsnMessage{
       counter: count,
       timestamp: time,
@@ -144,7 +148,10 @@ defmodule Orbit.Ocs.Parser.TschMessage do
     }
   end
 
-  defp parse_sub_type({count, time, transitline, ["DEL", trip_uid, delete_status]}, _emitted_time) do
+  defp parse_sub_type(
+         {count, time, transitline, ["DEL", trip_uid, delete_status | _extra]},
+         _emitted_time
+       ) do
     %Orbit.Ocs.Message.TschDelMessage{
       counter: count,
       timestamp: time,
@@ -155,7 +162,7 @@ defmodule Orbit.Ocs.Parser.TschMessage do
   end
 
   defp parse_sub_type(
-         {count, time, transitline, ["LNK", trip_uid, prev_trip_uid, next_trip_uid]},
+         {count, time, transitline, ["LNK", trip_uid, prev_trip_uid, next_trip_uid | _extra]},
          _emitted_time
        ) do
     prev_trip_uid = if prev_trip_uid == "0", do: nil, else: prev_trip_uid
@@ -171,7 +178,10 @@ defmodule Orbit.Ocs.Parser.TschMessage do
     }
   end
 
-  defp parse_sub_type({count, time, transitline, ["OFF", trip_uid, offset]}, _emitted_time) do
+  defp parse_sub_type(
+         {count, time, transitline, ["OFF", trip_uid, offset | _extra]},
+         _emitted_time
+       ) do
     %Orbit.Ocs.Message.TschOffMessage{
       counter: count,
       timestamp: time,
@@ -182,7 +192,8 @@ defmodule Orbit.Ocs.Parser.TschMessage do
   end
 
   defp parse_sub_type(
-         {count, time, transitline, ["DST", trip_uid, dest_sta, ocs_route_id_str, sched_arr_str]},
+         {count, time, transitline,
+          ["DST", trip_uid, dest_sta, ocs_route_id_str, sched_arr_str | _extra]},
          emitted_time
        ) do
     ocs_route_id =

--- a/test/orbit/ocs/parser/tsch_message_test.exs
+++ b/test/orbit/ocs/parser/tsch_message_test.exs
@@ -14,7 +14,14 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
     test "parses TSCH CON message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
                {4331, :tsch, @test_time,
-                ["R", "CON", "983AC23D", "1737 1736 1725 1724 1731 1730", "54466E3A"]},
+                [
+                  "R",
+                  "CON",
+                  "983AC23D",
+                  "1737 1736 1725 1724 1731 1730",
+                  "54466E3A",
+                  "extra_unexpected_field"
+                ]},
                @test_time
              ) ==
                {:ok,
@@ -47,7 +54,7 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH RLD message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {3081, :tsch, @test_time, ["O", "RLD", "W"]},
+               {3081, :tsch, @test_time, ["O", "RLD", "W", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,
@@ -86,7 +93,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
                   "OAK GROVE",
                   "FOREST HILLS",
                   "9866D294",
-                  "9866D296"
+                  "9866D296",
+                  "extra_unexpected_field"
                 ]},
                @test_time
              ) ==
@@ -111,7 +119,21 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
     test "parses TSCH NEW message with incomplete data (in this case, an RAD train)" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
                {28_329, :tsch, @test_time,
-                ["B", "NEW", "98AA06F7", "A", "R", "", "", "", "WONDERLAND", "", "0", "0"]},
+                [
+                  "B",
+                  "NEW",
+                  "98AA06F7",
+                  "A",
+                  "R",
+                  "",
+                  "",
+                  "",
+                  "WONDERLAND",
+                  "",
+                  "0",
+                  "0",
+                  "extra_unexpected_field"
+                ]},
                @test_time
              ) ==
                {:ok,
@@ -134,7 +156,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH DST message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {4520, :tsch, @test_time, ["R", "DST", "983BA807", "CADDIGAN YARD", "", ""]},
+               {4520, :tsch, @test_time,
+                ["R", "DST", "983BA807", "CADDIGAN YARD", "", "", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,
@@ -151,7 +174,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH ASN message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {4520, :tsch, @test_time, ["R", "ASN", "54466E3A", "983BA807"]},
+               {4520, :tsch, @test_time,
+                ["R", "ASN", "54466E3A", "983BA807", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,
@@ -166,7 +190,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH LNK message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {19_332, :tsch, @test_time, ["R", "LNK", "983BA716", "983BA715", "983BA710"]},
+               {19_332, :tsch, @test_time,
+                ["R", "LNK", "983BA716", "983BA715", "983BA710", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,
@@ -182,7 +207,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH LNK message with '0' trips as nil trips" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {19_223, :tsch, @test_time, ["R", "LNK", "983BA716", "983BA715", "0"]},
+               {19_223, :tsch, @test_time,
+                ["R", "LNK", "983BA716", "983BA715", "0", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,
@@ -198,7 +224,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH DEL message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {26_377, :tsch, @test_time, ["B", "DEL", "98A8F1AF", "0"]},
+               {26_377, :tsch, @test_time,
+                ["B", "DEL", "98A8F1AF", "0", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,
@@ -213,7 +240,8 @@ defmodule Orbit.Ocs.Message.TschMessageTest do
 
     test "parses TSCH OFF message" do
       assert Orbit.Ocs.Parser.TschMessage.parse(
-               {19_332, :tsch, @test_time, ["R", "OFF", "983BA716", "13579"]},
+               {19_332, :tsch, @test_time,
+                ["R", "OFF", "983BA716", "13579", "extra_unexpected_field"]},
                @test_time
              ) ==
                {:ok,


### PR DESCRIPTION
Asana Task: [🪐 OCS Data: Allow message parser to handle additional fields](https://app.asana.com/1/15492006741476/project/1200882337457260/task/1210872848363835?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

We are preparing to ask OCC to add explicit date fields at the end of certain `TSCH` messages (specifically `TSCH_NEW` and `TSCH_DST`), preferably appended at the end of the existing format, for easier backward compatibility. Unfortunately that would break our current parser, because we expect exact numbers of fields for each message type.

This change allows us to receive and ignore extra fields. (The exception is `TSCH_TAG` because that message does not specify a way to terminate the arbitrary-length list of tags at the end.) I don't know that we'll actually need this, but it will make us more resilient to unexpected changes.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
