### PR TITLE
fix: don't apply actual departure when at origin

### DIFF
--- a/lib/realtime/trip_matcher.ex
+++ b/lib/realtime/trip_matcher.ex
@@ -161,7 +161,7 @@ defmodule Realtime.TripMatcher do
     Enum.map(vehicles, fn vehicle ->
       %{ocs_trips: %{current: current}} = vehicle
 
-      if current != nil do
+      if current != nil and !at_scheduled_origin(vehicle) do
         origin_station = Stations.ocs_to_gtfs(current.origin_station)
         actual_departure = Map.get(events, {current.train_uid, origin_station})
         put_in(vehicle.ocs_trips.current.actual_departure, actual_departure)
@@ -169,5 +169,12 @@ defmodule Realtime.TripMatcher do
         vehicle
       end
     end)
+  end
+
+  @spec at_scheduled_origin(Vehicle.t()) :: boolean()
+  defp at_scheduled_origin(vehicle) do
+    vehicle.position.current_status == :STOPPED_AT and
+      vehicle.position.station_id ==
+        Stations.ocs_to_gtfs(vehicle.ocs_trips.current.origin_station)
   end
 end

--- a/test/realtime/trip_matcher_test.exs
+++ b/test/realtime/trip_matcher_test.exs
@@ -496,5 +496,25 @@ defmodule Realtime.TripMatcherTest do
       assert [%{ocs_trips: %{current: %{actual_departure: nil}}}] =
                TripMatcher.populate_actual_departures([vehicle], ~U[2025-07-08 19:30:00Z])
     end
+
+    test "does not get actual departure when haven't left yet (must be an older event)" do
+      ocs_trip = insert(:ocs_trip, train_uid: "5484208E")
+
+      vehicle =
+        build(:vehicle,
+          ocs_trips: %{current: ocs_trip},
+          position:
+            build(
+              :vehicle_position,
+              station_id: "place-asmnl",
+              current_status: :STOPPED_AT
+            )
+        )
+
+      insert(:vehicle_event, vehicle_id: "5484208E")
+
+      assert [%{ocs_trips: %{current: %{actual_departure: nil}}}] =
+               TripMatcher.populate_actual_departures([vehicle], ~U[2025-07-08 16:30:00Z])
+    end
   end
 end


### PR DESCRIPTION
Asana Task: [Sidebar: actual departure (track departures automatically)](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1209646113903412)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

If a vehicle is at its origin, it's probably getting an actual departure from earlier in the day (but within the cutoff). So we shouldn't display one in that case.

<img width="1298" height="892" alt="Screenshot 2025-07-24 at 1 23 53 PM" src="https://github.com/user-attachments/assets/a5c26eb4-10ab-406f-b0b0-3e9476b493b5" />


Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
