### PR TITLE
fix: don't apply actual departure when in Ashmont turnaround

### DIFF
--- a/lib/realtime/trip_matcher.ex
+++ b/lib/realtime/trip_matcher.ex
@@ -173,7 +173,15 @@ defmodule Realtime.TripMatcher do
 
   @spec at_scheduled_origin(Vehicle.t()) :: boolean()
   defp at_scheduled_origin(vehicle) do
-    vehicle.position.current_status == :STOPPED_AT and
+    # NB pm: Ashmont exception
+    #   Vehicles turning around south of Ashmont are IN_TRANSIT_TO Ashmont, but for the purposes of
+    #   determining whether we should show an Actual Departure, they are stopped there.
+    stopped =
+      vehicle.position.current_status == :STOPPED_AT or
+        (vehicle.position.station_id == "place-asmnl" and vehicle.position.direction == 1)
+
+    # Check if stopped at the OCS origin_station
+    stopped and
       vehicle.position.station_id ==
         Stations.ocs_to_gtfs(vehicle.ocs_trips.current.origin_station)
   end

--- a/test/realtime/trip_matcher_test.exs
+++ b/test/realtime/trip_matcher_test.exs
@@ -516,5 +516,26 @@ defmodule Realtime.TripMatcherTest do
       assert [%{ocs_trips: %{current: %{actual_departure: nil}}}] =
                TripMatcher.populate_actual_departures([vehicle], ~U[2025-07-08 16:30:00Z])
     end
+
+    test "does not get actual departure when south of Ashmont in the turnaround" do
+      ocs_trip = insert(:ocs_trip, train_uid: "5484208E")
+
+      vehicle =
+        build(:vehicle,
+          ocs_trips: %{current: ocs_trip},
+          position:
+            build(
+              :vehicle_position,
+              station_id: "place-asmnl",
+              current_status: :IN_TRANSIT_TO,
+              direction: 1
+            )
+        )
+
+      insert(:vehicle_event, vehicle_id: "5484208E")
+
+      assert [%{ocs_trips: %{current: %{actual_departure: nil}}}] =
+               TripMatcher.populate_actual_departures([vehicle], ~U[2025-07-08 16:30:00Z])
+    end
   end
 end


### PR DESCRIPTION
Asana Task: [Sidebar: actual departure (track departures automatically)](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1209646113903412)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

#374, but for when trains are at Ashmont but south of the station in the turnaround.


Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
