### PR TITLE
fix: negatives in late boxes

### DIFF
--- a/js/components/ladderPage/sidebar.tsx
+++ b/js/components/ladderPage/sidebar.tsx
@@ -126,7 +126,7 @@ const NextTrip = ({ vehicle }: { vehicle: Vehicle }) => {
       {showLateBox && (
         <Late
           departedLate={null}
-          arrivingLate={Math.round(nextDepMin)}
+          arrivingLate={nextDepMin}
           arrivingLateText={"next trip's departure time."}
         />
       )}
@@ -193,7 +193,7 @@ const Late = ({
             <p>
               Departed{" "}
               <span className="font-bold">
-                {Math.floor(departedLate)} min{" "}
+                {formatDelta(departedLate)} min{" "}
                 {departedLate >= 0 ? "late" : "early"}
               </span>
               .
@@ -203,7 +203,7 @@ const Late = ({
             <p>
               Arriving{" "}
               <span className="font-bold">
-                {Math.floor(arrivingLate)} min{" "}
+                {formatDelta(arrivingLate)} min{" "}
                 {arrivingLate >= 0 ? "later" : "earlier"}
               </span>{" "}
               than {arrivingLateText}
@@ -213,4 +213,8 @@ const Late = ({
       </div>
     </div>
   );
+};
+
+const formatDelta = (min: number) => {
+  return Math.abs(Math.floor(min));
 };

--- a/js/test/components/ladderPage/sidebar.test.tsx
+++ b/js/test/components/ladderPage/sidebar.test.tsx
@@ -205,7 +205,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min early/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min early/)).toBeInTheDocument();
       });
 
       test("shows if departed 5 minutes late", () => {
@@ -225,7 +225,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min late/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min late/)).toBeInTheDocument();
       });
 
       test("shows if departed 6 minutes late (but really 5 because of the offset)", () => {
@@ -246,7 +246,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min late/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min late/)).toBeInTheDocument();
       });
 
       test("does not show if departed 4 minutes late", () => {
@@ -266,7 +266,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.queryByText(/4 min late/)).not.toBeInTheDocument();
+        expect(view.queryByText(/^4 min late/)).not.toBeInTheDocument();
       });
 
       test("shows if arriving 5 minutes later than scheduled", () => {
@@ -288,7 +288,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min later/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min later/)).toBeInTheDocument();
       });
 
       test("shows if arriving 5 minutes earlier than scheduled (but also left late)", () => {
@@ -318,7 +318,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min earlier/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min earlier/)).toBeInTheDocument();
       });
 
       test("shows if arriving 5 minutes later than scheduled, but also left 5 min early", () => {
@@ -347,8 +347,8 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min later/)).toBeInTheDocument();
-        expect(view.getByText(/5 min early/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min later/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min early/)).toBeInTheDocument();
       });
 
       test("does not show if arriving 4 minutes later than scheduled", () => {
@@ -370,7 +370,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.queryByText(/4 min later/)).not.toBeInTheDocument();
+        expect(view.queryByText(/^4 min later/)).not.toBeInTheDocument();
       });
 
       test("shows if arriving 5 minutes later than next trip's scheduled departure", () => {
@@ -401,7 +401,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/5 min later/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min later/)).toBeInTheDocument();
       });
 
       test("does not show if arriving 4 minutes later than next trip's scheduled departure", () => {
@@ -432,7 +432,7 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.queryByText(/4 min later/)).not.toBeInTheDocument();
+        expect(view.queryByText(/^4 min later/)).not.toBeInTheDocument();
       });
 
       test("does not show if arriving 6 minutes earlier than next trip's scheduled departure", () => {
@@ -499,9 +499,9 @@ describe("sidebar", () => {
             close={() => {}}
           />,
         );
-        expect(view.getByText(/7 min late/)).toBeInTheDocument();
-        expect(view.getByText(/26 min later/)).toBeInTheDocument();
-        expect(view.getByText(/5 min later/)).toBeInTheDocument();
+        expect(view.getByText(/^7 min late/)).toBeInTheDocument();
+        expect(view.getByText(/^26 min later/)).toBeInTheDocument();
+        expect(view.getByText(/^5 min later/)).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Asana Task: [Sidebar: late notice box](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210172293290211)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

<img width="330" height="274" alt="image" src="https://github.com/user-attachments/assets/51216832-a054-49b9-bd2e-7b9fb547b1a3" />


Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
