### PR TITLE
fix: don't attach a TripUpdate to a Vehicle if the OCS trip has a different destination

### DIFF
--- a/lib/realtime/data/trip_update.ex
+++ b/lib/realtime/data/trip_update.ex
@@ -61,4 +61,17 @@ defmodule Realtime.Data.TripUpdate do
         nil
     end
   end
+
+  @spec last_arrival_stop(__MODULE__.t() | nil) :: String.t() | nil
+  def last_arrival_stop(nil), do: nil
+
+  def last_arrival_stop(trip_update) do
+    case List.last(trip_update.stop_time_updates) do
+      %StopTimeUpdate{station_id: id} ->
+        id
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/test/realtime/trip_matcher_test.exs
+++ b/test/realtime/trip_matcher_test.exs
@@ -6,6 +6,7 @@ defmodule Realtime.TripMatcherTest do
   alias Orbit.Ocs.Trip
   alias Orbit.Vehicle
   alias Realtime.Data.TripUpdate
+  alias Realtime.Data.TripUpdate.StopTimeUpdate
   alias Realtime.Data.VehiclePosition
   alias Realtime.TripMatcher
 
@@ -214,6 +215,46 @@ defmodule Realtime.TripMatcherTest do
                  }
                ],
                []
+             )
+  end
+
+  test "does not match a VehiclePosition to a TripUpdate if destination mismatch" do
+    assert [
+             %Vehicle{
+               trip_update: nil,
+               position: %VehiclePosition{
+                 vehicle_id: "R-5483E6C7",
+                 trip_id: "69349212"
+               }
+             }
+           ] =
+             Realtime.TripMatcher.match_trips(
+               [
+                 %VehiclePosition{
+                   vehicle_id: "R-5483E6C7",
+                   trip_id: "69349212"
+                 }
+               ],
+               [
+                 %TripUpdate{
+                   route_id: "Red",
+                   vehicle_id: "R-5483E6C7",
+                   trip_id: "69349212",
+                   stop_time_updates: [
+                     %StopTimeUpdate{
+                       station_id: "place-asmnl"
+                     }
+                   ]
+                 }
+               ],
+               [
+                 %Trip{
+                   train_uid: "5483E6C7",
+                   destination_station: "ALEWIFE",
+                   assigned_at: @test_datetime,
+                   uid: "1234FFAB"
+                 }
+               ]
              )
   end
 


### PR DESCRIPTION
Asana Task: [🪐 🐞 Only show estimated arrival if it's for the station listed](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210824268353890)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

This PR:
- Changes the TripMatcher to only attach a TripUpdate (TU) to a Vehicle if the "destination" of the TU (the last stop time update) matches the OCS destination.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
