### PR TITLE
fix: avoid event tracking crash if FS is not initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@
     - `brew install asdf`
     - You may need to run `asdf plugin add` some of `erlang`, `elixir`, or `nodejs`.
     - `asdf install`
-- For full functionality, also follow the steps in the "Receiving messages from OCS" section below.
+- For full functionality:
+  - Also follow the steps in the "Receiving messages from OCS" section below.
+  - Look inside `dev.secret.example.exs` for additional examples that can be configured inside
+    `dev.secret.exs`, such as for tools like Fullstory and Sentry.
 
 ## Set up
 

--- a/js/telemetry/trackingEvents.ts
+++ b/js/telemetry/trackingEvents.ts
@@ -1,12 +1,19 @@
 import { SideBarSelection } from "../components/ladderPage/sidebar";
 import { estimatedArrival } from "../models/tripUpdate";
-import { FullStory } from "@fullstory/browser";
+import {
+  FullStory,
+  isInitialized as isFullStoryInitialized,
+} from "@fullstory/browser";
 
 export enum FullStoryEventName {
   SideBarOpened = "Orbit: Ladder Side Bar Opened",
 }
 
 export const trackSideBarOpened = (selection: SideBarSelection) => {
+  if (!isFullStoryInitialized()) {
+    return;
+  }
+
   const { vehicle } = selection;
   const currentTrip = vehicle.ocsTrips.current;
   const nextTrip =

--- a/js/telemetry/trackingEvents.ts
+++ b/js/telemetry/trackingEvents.ts
@@ -1,19 +1,24 @@
 import { SideBarSelection } from "../components/ladderPage/sidebar";
 import { estimatedArrival } from "../models/tripUpdate";
 import {
-  FullStory,
+  FullStory as FS,
   isInitialized as isFullStoryInitialized,
 } from "@fullstory/browser";
+
+// Wrap Fullstory call with an initalization check. Otherwise, in cases where FS is not
+// initialized (primarily expected only in local development), calling FS() to track
+// an event results in a crash.
+const FullStory = (...params: Parameters<typeof FS>) => {
+  if (isFullStoryInitialized()) {
+    return FS(...params);
+  }
+};
 
 export enum FullStoryEventName {
   SideBarOpened = "Orbit: Ladder Side Bar Opened",
 }
 
 export const trackSideBarOpened = (selection: SideBarSelection) => {
-  if (!isFullStoryInitialized()) {
-    return;
-  }
-
   const { vehicle } = selection;
   const currentTrip = vehicle.ocsTrips.current;
   const nextTrip =

--- a/js/test/telemetry/trackingEvents.test.ts
+++ b/js/test/telemetry/trackingEvents.test.ts
@@ -8,6 +8,9 @@ import { FullStory } from "@fullstory/browser";
 
 jest.mock("@fullstory/browser", () => ({
   FullStory: jest.fn(),
+  // Mock and always return that FS has been initialized. This allows our tests to run against mock
+  // FS, even if Fullstory is not really configured/initalized for the test suite.
+  isInitialized: jest.fn().mockReturnValue(true),
 }));
 
 describe("trackSideBarOpened", () => {


### PR DESCRIPTION
This is a follow-up for Asana Task: [Tracking: fullstory event on sidebar open](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210572330010013?focus=true)

Custom event tracking for the sidebar relies on Orbit being configured with the FS org ID, which can be set locally in `dev.secret.exs`. If this ID is missing, FS is not initialized, which is fine, except that this causes the side bar event to crash, preventing the side bar from opening.

This adds an explicit check for initialization, and if not, skips the event. 

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(X)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
