### PR TITLE
fix: revise trip matcher splunk stats for "missing" trip fields

### DIFF
--- a/lib/realtime/trip_matcher.ex
+++ b/lib/realtime/trip_matcher.ex
@@ -108,6 +108,8 @@ defmodule Realtime.TripMatcher do
             nil -> nil
           end
 
+        ignore_next_trip = vehicle.ocs_trips.current && vehicle.ocs_trips.current.next_uid == nil
+
         ignore_actual_departure? =
           vehicle.ocs_trips.current && !vehicle.ocs_trips.current.departed
 
@@ -122,10 +124,14 @@ defmodule Realtime.TripMatcher do
             get_in(vehicle.ocs_trips.current.scheduled_arrival),
           missing_current_estimated_arrival_time:
             TripUpdate.last_arrival_time(get_in(vehicle.trip_update)),
-          missing_next_departure_station: next_trip && next_trip.origin_station,
-          missing_next_scheduled_departure_time: next_trip && next_trip.scheduled_departure,
-          missing_next_arrival_station: next_trip && next_trip.destination_station,
-          missing_next_scheduled_arrival_time: next_trip && next_trip.scheduled_arrival
+          missing_next_departure_station:
+            ignore_next_trip || (next_trip && next_trip.origin_station),
+          missing_next_scheduled_departure_time:
+            ignore_next_trip || (next_trip && next_trip.scheduled_departure),
+          missing_next_arrival_station:
+            ignore_next_trip || (next_trip && next_trip.destination_station),
+          missing_next_scheduled_arrival_time:
+            ignore_next_trip || (next_trip && next_trip.scheduled_arrival)
         }
 
         checks

--- a/lib/realtime/trip_matcher.ex
+++ b/lib/realtime/trip_matcher.ex
@@ -108,11 +108,15 @@ defmodule Realtime.TripMatcher do
             nil -> nil
           end
 
+        ignore_actual_departure? =
+          vehicle.ocs_trips.current && !vehicle.ocs_trips.current.departed
+
         checks = %{
           missing_current_departure_station: get_in(vehicle.ocs_trips.current.origin_station),
           missing_current_scheduled_departure_time:
             get_in(vehicle.ocs_trips.current.scheduled_departure),
-          missing_current_actual_departure_time: nil,
+          missing_current_actual_departure_time:
+            ignore_actual_departure? || get_in(vehicle.ocs_trips.current.actual_departure),
           missing_current_arrival_station: get_in(vehicle.ocs_trips.current.destination_station),
           missing_current_scheduled_arrival_time:
             get_in(vehicle.ocs_trips.current.scheduled_arrival),

--- a/test/realtime/trip_matcher_test.exs
+++ b/test/realtime/trip_matcher_test.exs
@@ -259,6 +259,73 @@ defmodule Realtime.TripMatcherTest do
   end
 
   describe "statistics" do
+    test "everything present" do
+      assert %{
+               missing_current_actual_departure_time: [],
+               missing_current_arrival_station: [],
+               missing_current_departure_station: [],
+               missing_current_estimated_arrival_time: [],
+               missing_current_scheduled_arrival_time: [],
+               missing_current_scheduled_departure_time: [],
+               missing_next_arrival_station: [],
+               missing_next_departure_station: [],
+               missing_next_scheduled_arrival_time: [],
+               missing_next_scheduled_departure_time: [],
+               total: 1
+             } ==
+               TripMatcher.statistics([
+                 build(:vehicle,
+                   ocs_trips: %{
+                     current:
+                       build(
+                         :ocs_trip,
+                         departed: true,
+                         actual_departure: ~U[2025-06-06 12:00:00Z]
+                       ),
+                     next: [
+                       build(:ocs_trip)
+                     ]
+                   },
+                   position: %VehiclePosition{
+                     vehicle_id: "VEHICLE_ID"
+                   }
+                 )
+               ])
+    end
+
+    test "everything present (with explicitly unset next trip)" do
+      assert %{
+               missing_current_actual_departure_time: [],
+               missing_current_arrival_station: [],
+               missing_current_departure_station: [],
+               missing_current_estimated_arrival_time: [],
+               missing_current_scheduled_arrival_time: [],
+               missing_current_scheduled_departure_time: [],
+               missing_next_arrival_station: [],
+               missing_next_departure_station: [],
+               missing_next_scheduled_arrival_time: [],
+               missing_next_scheduled_departure_time: [],
+               total: 1
+             } ==
+               TripMatcher.statistics([
+                 build(:vehicle,
+                   ocs_trips: %{
+                     current:
+                       build(
+                         :ocs_trip,
+                         next_uid: nil,
+                         departed: true,
+                         actual_departure: ~U[2025-06-06 12:00:00Z]
+                       ),
+                     next: []
+                   },
+                   position: %VehiclePosition{
+                     vehicle_id: "VEHICLE_ID"
+                   }
+                 )
+               ])
+    end
+
     test "everything missing" do
       assert %{
                missing_current_actual_departure_time: ["VEHICLE_ID"],
@@ -283,6 +350,33 @@ defmodule Realtime.TripMatcherTest do
                      vehicle_id: "VEHICLE_ID"
                    }
                  }
+               ])
+    end
+
+    test "next trip missing" do
+      assert %{
+               missing_current_actual_departure_time: [],
+               missing_current_arrival_station: [],
+               missing_current_departure_station: [],
+               missing_current_estimated_arrival_time: [],
+               missing_current_scheduled_arrival_time: [],
+               missing_current_scheduled_departure_time: [],
+               missing_next_arrival_station: ["VEHICLE_ID"],
+               missing_next_departure_station: ["VEHICLE_ID"],
+               missing_next_scheduled_arrival_time: ["VEHICLE_ID"],
+               missing_next_scheduled_departure_time: ["VEHICLE_ID"],
+               total: 1
+             } ==
+               TripMatcher.statistics([
+                 build(:vehicle,
+                   ocs_trips: %{
+                     current: build(:ocs_trip, next_uid: "23456789"),
+                     next: []
+                   },
+                   position: %VehiclePosition{
+                     vehicle_id: "VEHICLE_ID"
+                   }
+                 )
                ])
     end
 

--- a/test/realtime/trip_matcher_test.exs
+++ b/test/realtime/trip_matcher_test.exs
@@ -326,7 +326,7 @@ defmodule Realtime.TripMatcherTest do
                ])
     end
 
-    test "missing_current_actual_departure_time" do
+    test "missing_current_actual_departure_time (logged for departed trip)" do
       assert %{
                missing_current_actual_departure_time: ["R-547210A7"]
              } =
@@ -337,9 +337,25 @@ defmodule Realtime.TripMatcherTest do
                    ocs_trips: %{
                      current:
                        build(
-                         :ocs_trip
-                         # TODO: When we implement Actual Departure, this should be hooked up
+                         :ocs_trip,
+                         departed: true
                        ),
+                     next: []
+                   }
+                 }
+               ])
+    end
+
+    test "missing_current_actual_departure_time (not logged if trip has not departed)" do
+      assert %{
+               missing_current_actual_departure_time: []
+             } =
+               TripMatcher.statistics([
+                 %Vehicle{
+                   trip_update: build(:trip_update),
+                   position: build(:vehicle_position),
+                   ocs_trips: %{
+                     current: build(:ocs_trip),
                      next: []
                    }
                  }


### PR DESCRIPTION
Asana Task: [🪐🐞 Orbit: Fix trip matcher "missing" stats in splunk](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1211008266929600?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Two changes:

- Log that the actual departure for the current trip is missing only if we are actually missing the departure time. (Previously this was just always reporting as missing for every trip.)
  - If the current trip itself is missing, then departure time is also considered missing
  - If the current trip is present _and has departed_, then log if the actual departure time is missing.
  
- For cases where we have a current trip with no next trip UID, then _do not_ log that the missing trip fields are missing, as this is a case where the next trip is considered explicitly unset by OCS.

Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `(X)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
