### PR TITLE
fix: add pulse animation to entire div

### DIFF
--- a/js/components/ladderPage/train.tsx
+++ b/js/components/ladderPage/train.tsx
@@ -125,7 +125,7 @@ export const Train = ({
   const label = vehicle.vehiclePosition.label;
   const displayLabel = remapLabel(label, vehicle.vehiclePosition.routeId);
   return (
-    <div className="relative">
+    <div className={className(["relative", highlight ? "animate-pulse" : ""])}>
       {/* line that connects to dot */}
       {/* the bounding box is determined by the pill button. the svg element must be transformed such that its
       dimensions covers the area between the dot and the pill in order to render the line that connects them */}
@@ -157,7 +157,7 @@ export const Train = ({
       <button
         className={className([
           "pointer-events-auto m-1 relative items-center justify-center rounded-3xl w-24 h-10 font-semibold bg-white",
-          highlight ? "border-[3px] animate-pulse" : "border",
+          highlight ? "border-[3px]" : "border",
           theme.borderColor,
           extraClassName,
         ])}


### PR DESCRIPTION
Asana Task: [Implement pill overlap](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210229337734767?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

In the initial implementation of pill overlaps, when a pill is selecting and begins "pulsing" the line connecting the pill to its dot on the ladder becomes visible and "pokes out" into the pill. This fix makes the entirety of the pill + connecting line + dot pulse together to avoid this.

Design ok'd this fix via slack [thread](https://mbta.slack.com/archives/G8Y8HEY2D/p1756223835570809)

<img width="246" height="200" alt="Screenshot 2025-08-26 at 12 19 08 PM" src="https://github.com/user-attachments/assets/fa87879d-8421-4079-aed3-3660fc553c73" />


Checklist

<!-- check one from each section with (x) -->

- Tests:
  - `( )` Has tests
  - `(X)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(X)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
