### PR TITLE
fix: Estimated Arrival Time during diversion

### DIFF
--- a/js/components/ladderPage/sidebar.tsx
+++ b/js/components/ladderPage/sidebar.tsx
@@ -1,10 +1,8 @@
-import { formatStationName, gtfsToOcsStationName } from "../../data/stations";
+import { DateTime } from "luxon";
+import { formatStationName, gtfsToOcsStationName, ocsStationNameToGtfs } from "../../data/stations";
 import { dateTimeFormat } from "../../dateTime";
 import { CarId } from "../../models/common";
-import {
-  estimatedArrival,
-  lastArrivalStationId,
-} from "../../models/tripUpdate";
+import { estimatedArrival } from "../../models/tripUpdate";
 import {
   lateArrival,
   lateDeparture,
@@ -77,29 +75,25 @@ const Consist = ({ vehicle }: { vehicle: Vehicle }) => {
 const CurrentTrip = ({ vehicle }: { vehicle: Vehicle }) => {
   const current = vehicle.ocsTrips.current;
 
-  // The last prediction in the TripUpdate (i.e. the destination) must match the OCS
-  // trip. Before this, vehicles at Ashmont SB that are assigned to the next NB
-  // trip in OCS, but not RTR yet (due to the turnaround), will have an old estimated arrival
-  // https://app.asana.com/1/15492006741476/project/1206105669438487/task/1210824268353890
-  //
-  // However, if the OCS trip is missing the destination (ie. bad/missing data from OCS)
-  // then ignore this criteria.
-  const ocsDestinationStationId = vehicle.ocsTrips.current?.destinationStation;
-  const rtrLastArrivalStationId = lastArrivalStationId(vehicle.tripUpdate);
+  const estArrival: DateTime | null = ((): DateTime | null => {
+    // The last prediction in the TripUpdate (i.e. the destination) must match the OCS
+    // trip. Before this, vehicles at Ashmont SB that are assigned to the next NB
+    // trip in OCS, but not RTR yet (due to the turnaround), will have an old estimated arrival
+    // https://app.asana.com/1/15492006741476/project/1206105669438487/task/1210824268353890
+    //
+    // However, if the OCS trip is missing the destination (ie. bad/missing data from OCS)
+    // then ignore this criteria.
+    const ocsDestinationStationId = current?.destinationStation;
 
-  const rtrLastArrivalStationOcsName =
-    rtrLastArrivalStationId !== null ?
-      gtfsToOcsStationName(rtrLastArrivalStationId)
-    : null;
-
-  const estArrival =
-    (
-      ocsDestinationStationId === null ||
-      ocsDestinationStationId === undefined ||
-      ocsDestinationStationId === rtrLastArrivalStationOcsName
-    ) ?
-      estimatedArrival(vehicle.tripUpdate)
-    : null;
+    if (!!ocsDestinationStationId) {
+      const rtrStationIdForOcsDestinationStation = ocsStationNameToGtfs(ocsDestinationStationId);
+      return vehicle.tripUpdate?.stopTimeUpdates.find(stopTimeUpdate => {
+        stopTimeUpdate.stationId === rtrStationIdForOcsDestinationStation
+      })?.predictedArrivalTime ?? null;
+    } else {
+      return estimatedArrival(vehicle.tripUpdate)
+    }
+  })();
 
   const lateDepMin = lateDeparture(vehicle);
   // only calculate late arrival if using estimated arrival time

--- a/js/components/ladderPage/sidebar.tsx
+++ b/js/components/ladderPage/sidebar.tsx
@@ -2,7 +2,7 @@ import { DateTime } from "luxon";
 import { formatStationName, gtfsToOcsStationName, ocsStationNameToGtfs } from "../../data/stations";
 import { dateTimeFormat } from "../../dateTime";
 import { CarId } from "../../models/common";
-import { estimatedArrival } from "../../models/tripUpdate";
+import { predictedArrivalTimeForOcsStationId } from "../../models/tripUpdate";
 import {
   lateArrival,
   lateDeparture,
@@ -75,25 +75,11 @@ const Consist = ({ vehicle }: { vehicle: Vehicle }) => {
 const CurrentTrip = ({ vehicle }: { vehicle: Vehicle }) => {
   const current = vehicle.ocsTrips.current;
 
-  const estArrival: DateTime | null = ((): DateTime | null => {
-    // The last prediction in the TripUpdate (i.e. the destination) must match the OCS
-    // trip. Before this, vehicles at Ashmont SB that are assigned to the next NB
-    // trip in OCS, but not RTR yet (due to the turnaround), will have an old estimated arrival
-    // https://app.asana.com/1/15492006741476/project/1206105669438487/task/1210824268353890
-    //
-    // However, if the OCS trip is missing the destination (ie. bad/missing data from OCS)
-    // then ignore this criteria.
-    const ocsDestinationStationId = current?.destinationStation;
-
-    if (!!ocsDestinationStationId) {
-      const rtrStationIdForOcsDestinationStation = ocsStationNameToGtfs(ocsDestinationStationId);
-      return vehicle.tripUpdate?.stopTimeUpdates.find(stopTimeUpdate => {
-        stopTimeUpdate.stationId === rtrStationIdForOcsDestinationStation
-      })?.predictedArrivalTime ?? null;
-    } else {
-      return estimatedArrival(vehicle.tripUpdate)
-    }
-  })();
+  // OCS Destination must be present to provide an estimated arrival
+  const estArrival: DateTime | null = predictedArrivalTimeForOcsStationId(
+    vehicle.tripUpdate?.stopTimeUpdates, 
+    current?.destinationStation,
+  );
 
   const lateDepMin = lateDeparture(vehicle);
   // only calculate late arrival if using estimated arrival time

--- a/js/components/ladderPage/sidebar.tsx
+++ b/js/components/ladderPage/sidebar.tsx
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { formatStationName, gtfsToOcsStationName, ocsStationNameToGtfs } from "../../data/stations";
+import { formatStationName } from "../../data/stations";
 import { dateTimeFormat } from "../../dateTime";
 import { CarId } from "../../models/common";
 import { estimatedArrival } from "../../models/tripUpdate";

--- a/js/components/ladderPage/sidebar.tsx
+++ b/js/components/ladderPage/sidebar.tsx
@@ -2,7 +2,7 @@ import { DateTime } from "luxon";
 import { formatStationName, gtfsToOcsStationName, ocsStationNameToGtfs } from "../../data/stations";
 import { dateTimeFormat } from "../../dateTime";
 import { CarId } from "../../models/common";
-import { predictedArrivalTimeForOcsStationId } from "../../models/tripUpdate";
+import { estimatedArrival } from "../../models/tripUpdate";
 import {
   lateArrival,
   lateDeparture,
@@ -75,11 +75,7 @@ const Consist = ({ vehicle }: { vehicle: Vehicle }) => {
 const CurrentTrip = ({ vehicle }: { vehicle: Vehicle }) => {
   const current = vehicle.ocsTrips.current;
 
-  // OCS Destination must be present to provide an estimated arrival
-  const estArrival: DateTime | null = predictedArrivalTimeForOcsStationId(
-    vehicle.tripUpdate?.stopTimeUpdates, 
-    current?.destinationStation,
-  );
+  const estArrival: DateTime | null = estimatedArrival(vehicle);
 
   const lateDepMin = lateDeparture(vehicle);
   // only calculate late arrival if using estimated arrival time

--- a/js/components/ladderPage/sidebar.tsx
+++ b/js/components/ladderPage/sidebar.tsx
@@ -1,4 +1,3 @@
-import { DateTime } from "luxon";
 import { formatStationName } from "../../data/stations";
 import { dateTimeFormat } from "../../dateTime";
 import { CarId } from "../../models/common";
@@ -13,6 +12,7 @@ import {
 import { remapLabels, reorder } from "../../util/consist";
 import { className } from "../../util/dom";
 import { isFeatureEnabled } from "../../util/featureFlags";
+import { DateTime } from "luxon";
 import { ReactElement, useState } from "react";
 
 export type SideBarSelection = {

--- a/js/data/stations.ts
+++ b/js/data/stations.ts
@@ -238,8 +238,11 @@ export const formatStationName = (station: string | null | undefined) => {
 };
 
 export const ocsStationNameToGtfs = (ocsStationName: string): string | null => {
-  return Object.values(Stations)
-    .flat()
-    .flat()
-    .find((station) => station.ocs_station_name === ocsStationName)?.id ?? null;
-}
+  return (
+    Object.values(Stations)
+      .flat()
+      .flat()
+      .find((station) => station.ocs_station_name === ocsStationName)?.id ??
+    null
+  );
+};

--- a/js/data/stations.ts
+++ b/js/data/stations.ts
@@ -237,13 +237,6 @@ export const formatStationName = (station: string | null | undefined) => {
   );
 };
 
-export const gtfsToOcsStationName = (stationId: string) => {
-  return Object.values(Stations)
-    .flat()
-    .flat()
-    .find((station) => station.id === stationId)?.ocs_station_name;
-};
-
 export const ocsStationNameToGtfs = (ocsStationName: string): string | null => {
   return Object.values(Stations)
     .flat()

--- a/js/data/stations.ts
+++ b/js/data/stations.ts
@@ -243,3 +243,10 @@ export const gtfsToOcsStationName = (stationId: string) => {
     .flat()
     .find((station) => station.id === stationId)?.ocs_station_name;
 };
+
+export const ocsStationNameToGtfs = (ocsStationName: string): string | null => {
+  return Object.values(Stations)
+    .flat()
+    .flat()
+    .find((station) => station.ocs_station_name === ocsStationName)?.id ?? null;
+}

--- a/js/data/stations.ts
+++ b/js/data/stations.ts
@@ -240,8 +240,7 @@ export const formatStationName = (station: string | null | undefined) => {
 export const ocsStationNameToGtfs = (ocsStationName: string): string | null => {
   return (
     Object.values(Stations)
-      .flat()
-      .flat()
+      .flat(2)
       .find((station) => station.ocs_station_name === ocsStationName)?.id ??
     null
   );

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -68,11 +68,11 @@ export type TripUpdateData = z.infer<typeof TripUpdateData>;
 
 export const estimatedArrival = (vehicle: Vehicle): DateTime | null => {
   const gtfsStopId = ocsStationNameToGtfs(
-    vehicle.ocsTrips?.current?.destinationStation ?? "",
+    vehicle.ocsTrips.current?.destinationStation ?? "",
   );
 
   return (
-    vehicle.tripUpdate?.stopTimeUpdates?.find((stopTimeUpdate) => {
+    vehicle.tripUpdate?.stopTimeUpdates.find((stopTimeUpdate) => {
       return stopTimeUpdate.stationId === gtfsStopId;
     })?.predictedArrivalTime ?? null
   );

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -64,19 +64,18 @@ export const TripUpdateData = z.object({
 });
 export type TripUpdateData = z.infer<typeof TripUpdateData>;
 
-export const estimatedArrival = (tu?: TripUpdate): DateTime | null => {
-  if (tu == undefined || tu.stopTimeUpdates.length === 0) {
-    return null;
-  }
+const stopTimeUpdateForLastArrivalStation = (stopTimeUpdates: StopTimeUpdate[] | null | undefined): StopTimeUpdate | null => {
+  if (!stopTimeUpdates || stopTimeUpdates.length == 0) return null;
 
-  const stu = tu.stopTimeUpdates[tu.stopTimeUpdates.length - 1];
-  return stu.predictedArrivalTime;
+  return stopTimeUpdates.filter(
+    value => !!value?.predictedArrivalTime,
+  )[stopTimeUpdates.length - 1]
+}
+
+export const estimatedArrival = (tu?: TripUpdate): DateTime | null => {
+  return stopTimeUpdateForLastArrivalStation(tu?.stopTimeUpdates)?.predictedArrivalTime ?? null;
 };
 
 export const lastArrivalStationId = (tu?: TripUpdate): string | null => {
-  if (tu == undefined || tu.stopTimeUpdates.length === 0) {
-    return null;
-  }
-
-  return tu.stopTimeUpdates[tu.stopTimeUpdates.length - 1].stationId;
+  return stopTimeUpdateForLastArrivalStation(tu?.stopTimeUpdates)?.stationId ?? null;
 };

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -69,7 +69,9 @@ export type TripUpdateData = z.infer<typeof TripUpdateData>;
 export const estimatedArrival = (
   vehicle: Vehicle
 ): DateTime | null => {
+  const gtfsStopId = ocsStationNameToGtfs(vehicle.ocsTrips.current?.destinationStation ?? "");
+  
   return vehicle.tripUpdate?.stopTimeUpdates?.find(stopTimeUpdate => {
-    return stopTimeUpdate.stationId === ocsStationNameToGtfs(vehicle.ocsTrips.current?.destinationStation ?? "")
+    return stopTimeUpdate.stationId === gtfsStopId
   })?.predictedArrivalTime ?? null;
 };

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -70,6 +70,6 @@ export const estimatedArrival = (
   vehicle: Vehicle
 ): DateTime | null => {
   return vehicle.tripUpdate?.stopTimeUpdates?.find(stopTimeUpdate => {
-    stopTimeUpdate.stationId === ocsStationNameToGtfs(vehicle.ocsTrips.current?.destinationStation ?? "")
+    return stopTimeUpdate.stationId === ocsStationNameToGtfs(vehicle.ocsTrips.current?.destinationStation ?? "")
   })?.predictedArrivalTime ?? null;
 };

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -68,7 +68,7 @@ export type TripUpdateData = z.infer<typeof TripUpdateData>;
 
 export const estimatedArrival = (vehicle: Vehicle): DateTime | null => {
   const gtfsStopId = ocsStationNameToGtfs(
-    vehicle.ocsTrips.current?.destinationStation ?? "",
+    vehicle.ocsTrips?.current?.destinationStation ?? "",
   );
 
   return (

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -1,9 +1,9 @@
 import { ocsStationNameToGtfs } from "../data/stations";
 import { dateTimeFromUnix } from "../dateTime";
 import { RouteId } from "./common";
+import { Vehicle } from "./vehicle";
 import { DateTime } from "luxon";
 import { z } from "zod";
-import { Vehicle } from "./vehicle";
 
 export const StopTimeUpdateData = z.object({
   station_id: z.string(),
@@ -66,12 +66,14 @@ export const TripUpdateData = z.object({
 });
 export type TripUpdateData = z.infer<typeof TripUpdateData>;
 
-export const estimatedArrival = (
-  vehicle: Vehicle
-): DateTime | null => {
-  const gtfsStopId = ocsStationNameToGtfs(vehicle.ocsTrips.current?.destinationStation ?? "");
-  
-  return vehicle.tripUpdate?.stopTimeUpdates?.find(stopTimeUpdate => {
-    return stopTimeUpdate.stationId === gtfsStopId
-  })?.predictedArrivalTime ?? null;
+export const estimatedArrival = (vehicle: Vehicle): DateTime | null => {
+  const gtfsStopId = ocsStationNameToGtfs(
+    vehicle.ocsTrips.current?.destinationStation ?? "",
+  );
+
+  return (
+    vehicle.tripUpdate?.stopTimeUpdates?.find((stopTimeUpdate) => {
+      return stopTimeUpdate.stationId === gtfsStopId;
+    })?.predictedArrivalTime ?? null
+  );
 };

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -3,6 +3,7 @@ import { dateTimeFromUnix } from "../dateTime";
 import { RouteId } from "./common";
 import { DateTime } from "luxon";
 import { z } from "zod";
+import { Vehicle } from "./vehicle";
 
 export const StopTimeUpdateData = z.object({
   station_id: z.string(),
@@ -65,27 +66,10 @@ export const TripUpdateData = z.object({
 });
 export type TripUpdateData = z.infer<typeof TripUpdateData>;
 
-export const predictedArrivalTimeForOcsStationId = (
-  stopTimeUpdates: StopTimeUpdate[] | null | undefined, 
-  ocsStationId: string | null | undefined,
-) => {
-  if (!ocsStationId) return null;
-
-  return stopTimeUpdates?.find(stopTimeUpdate => {
-    stopTimeUpdate.stationId === ocsStationNameToGtfs(ocsStationId)
+export const estimatedArrival = (
+  vehicle: Vehicle
+): DateTime | null => {
+  return vehicle.tripUpdate?.stopTimeUpdates?.find(stopTimeUpdate => {
+    stopTimeUpdate.stationId === ocsStationNameToGtfs(vehicle.ocsTrips.current?.destinationStation ?? "")
   })?.predictedArrivalTime ?? null;
-};
-
-const stopTimeUpdateForLastStation = (stopTimeUpdates: StopTimeUpdate[] | null | undefined): StopTimeUpdate | null => {
-  if (!stopTimeUpdates || stopTimeUpdates.length == 0) return null;
-
-  return stopTimeUpdates[stopTimeUpdates.length - 1];
-}
-
-export const estimatedArrival = (tu?: TripUpdate): DateTime | null => {
-  return stopTimeUpdateForLastStation(tu?.stopTimeUpdates)?.predictedArrivalTime ?? null;
-};
-
-export const lastArrivalStationId = (tu?: TripUpdate): string | null => {
-  return stopTimeUpdateForLastStation(tu?.stopTimeUpdates)?.stationId ?? null;
 };

--- a/js/models/tripUpdate.ts
+++ b/js/models/tripUpdate.ts
@@ -1,3 +1,4 @@
+import { ocsStationNameToGtfs } from "../data/stations";
 import { dateTimeFromUnix } from "../dateTime";
 import { RouteId } from "./common";
 import { DateTime } from "luxon";
@@ -64,18 +65,27 @@ export const TripUpdateData = z.object({
 });
 export type TripUpdateData = z.infer<typeof TripUpdateData>;
 
-const stopTimeUpdateForLastArrivalStation = (stopTimeUpdates: StopTimeUpdate[] | null | undefined): StopTimeUpdate | null => {
+export const predictedArrivalTimeForOcsStationId = (
+  stopTimeUpdates: StopTimeUpdate[] | null | undefined, 
+  ocsStationId: string | null | undefined,
+) => {
+  if (!ocsStationId) return null;
+
+  return stopTimeUpdates?.find(stopTimeUpdate => {
+    stopTimeUpdate.stationId === ocsStationNameToGtfs(ocsStationId)
+  })?.predictedArrivalTime ?? null;
+};
+
+const stopTimeUpdateForLastStation = (stopTimeUpdates: StopTimeUpdate[] | null | undefined): StopTimeUpdate | null => {
   if (!stopTimeUpdates || stopTimeUpdates.length == 0) return null;
 
-  return stopTimeUpdates.filter(
-    value => !!value?.predictedArrivalTime,
-  )[stopTimeUpdates.length - 1]
+  return stopTimeUpdates[stopTimeUpdates.length - 1];
 }
 
 export const estimatedArrival = (tu?: TripUpdate): DateTime | null => {
-  return stopTimeUpdateForLastArrivalStation(tu?.stopTimeUpdates)?.predictedArrivalTime ?? null;
+  return stopTimeUpdateForLastStation(tu?.stopTimeUpdates)?.predictedArrivalTime ?? null;
 };
 
 export const lastArrivalStationId = (tu?: TripUpdate): string | null => {
-  return stopTimeUpdateForLastArrivalStation(tu?.stopTimeUpdates)?.stationId ?? null;
+  return stopTimeUpdateForLastStation(tu?.stopTimeUpdates)?.stationId ?? null;
 };

--- a/js/models/vehicle.ts
+++ b/js/models/vehicle.ts
@@ -103,7 +103,7 @@ export const lateDeparture = (vehicle: Vehicle): number | null => {
  */
 export const lateArrival = (vehicle: Vehicle): number | null => {
   const scheduled = vehicle.ocsTrips.current?.scheduledArrival;
-  const estimated = estimatedArrival(vehicle.tripUpdate);
+  const estimated = estimatedArrival(vehicle);
 
   if (scheduled === null || scheduled === undefined || estimated === null) {
     return null;
@@ -123,7 +123,7 @@ export const lateForNext = (vehicle: Vehicle): number | null => {
     return null;
   }
 
-  const estimated = estimatedArrival(vehicle.tripUpdate);
+  const estimated = estimatedArrival(vehicle);
   const nextDeparture = nextTrip.scheduledDeparture;
 
   if (estimated === null || nextDeparture === null) {

--- a/js/telemetry/trackingEvents.ts
+++ b/js/telemetry/trackingEvents.ts
@@ -34,7 +34,7 @@ export const trackSideBarOpened = (selection: SideBarSelection) => {
       !currentTrip || (currentTrip.departed && !currentTrip.actualDeparture),
 
     // Other fields associated with current trip
-    current_estimated_arrival: !estimatedArrival(vehicle.tripUpdate),
+    current_estimated_arrival: !estimatedArrival(vehicle),
   };
 
   // If we have a currentTrip, and said trip does not have an assigned nextUid, then assume

--- a/js/test/components/ladderPage/sidebar.test.tsx
+++ b/js/test/components/ladderPage/sidebar.test.tsx
@@ -641,15 +641,22 @@ describe("sidebar", () => {
           <SideBar
             selection={{
               vehicle: vehicleFactory.build({
-                tripUpdate: tripUpdateFactory.build({ stopTimeUpdates: [
-                  stopTimeUpdateFactory.build({
-                    predictedArrivalTime: dateTimeFromISO("2025-04-29T21:51:38Z"),
-                    stationId: "place-brdwy",
-                  }),
-                  stopTimeUpdateFactory.build({
-                    predictedArrivalTime: dateTimeFromISO("2025-04-29T21:53:38Z"),
-                    stationId: "place-asmnl",
-                  })] }),
+                tripUpdate: tripUpdateFactory.build({
+                  stopTimeUpdates: [
+                    stopTimeUpdateFactory.build({
+                      predictedArrivalTime: dateTimeFromISO(
+                        "2025-04-29T21:51:38Z",
+                      ),
+                      stationId: "place-brdwy",
+                    }),
+                    stopTimeUpdateFactory.build({
+                      predictedArrivalTime: dateTimeFromISO(
+                        "2025-04-29T21:53:38Z",
+                      ),
+                      stationId: "place-asmnl",
+                    }),
+                  ],
+                }),
                 ocsTrips: {
                   current: ocsTripFactory.build({
                     originStation: "ALEWIFE",

--- a/js/test/components/ladderPage/sidebar.test.tsx
+++ b/js/test/components/ladderPage/sidebar.test.tsx
@@ -636,6 +636,35 @@ describe("sidebar", () => {
         expect(view.getByText("5:51p")).toBeInTheDocument();
       });
 
+      test("is arrival prediction for OCS provided destination even if RTR provides additional STUs", () => {
+        const view = render(
+          <SideBar
+            selection={{
+              vehicle: vehicleFactory.build({
+                tripUpdate: tripUpdateFactory.build({ stopTimeUpdates: [
+                  stopTimeUpdateFactory.build({
+                    predictedArrivalTime: dateTimeFromISO("2025-04-29T21:51:38Z"),
+                    stationId: "place-brdwy",
+                  }),
+                  stopTimeUpdateFactory.build({
+                    predictedArrivalTime: dateTimeFromISO("2025-04-29T21:53:38Z"),
+                    stationId: "place-asmnl",
+                  })] }),
+                ocsTrips: {
+                  current: ocsTripFactory.build({
+                    originStation: "ALEWIFE",
+                    destinationStation: "BROADWAY",
+                  }),
+                  next: [ocsTripFactory.build()],
+                },
+              }),
+            }}
+            close={() => {}}
+          />,
+        );
+        expect(view.getByText("5:51p")).toBeInTheDocument();
+      });
+
       // NOTE: when other sidebar fields are hooked up, perhaps consolidate testing
       // for "---" placeholders into one test mocking missing data for all fields
       test("displays '---' when unavailable", () => {

--- a/js/test/telemetry/trackingEvents.test.ts
+++ b/js/test/telemetry/trackingEvents.test.ts
@@ -54,6 +54,7 @@ describe("trackSideBarOpened", () => {
           missing_data: [
             "current_actual_departure",
             "current_destination_station",
+            "current_estimated_arrival",
             "current_origin_station",
             "current_scheduled_arrival",
             "current_scheduled_departure",
@@ -92,6 +93,7 @@ describe("trackSideBarOpened", () => {
           ocs_next_trip_uid: null,
           missing_data: [
             "current_destination_station",
+            "current_estimated_arrival",
             "current_origin_station",
             "current_scheduled_arrival",
             "current_scheduled_departure",


### PR DESCRIPTION
Asana Task: [🐞 Orbit 'Estimated' arrival not working during RL diversion](https://app.asana.com/1/15492006741476/project/1200882337457260/task/1214494378895416?focus=true)

Updated estimated arrival time to show the time for the STU that matches the destination station from OCS. If there isn't a match or OCS doesn't return destination data, show "---" as before.

Checklist
- Appearance:
  - `( )` Light & dark mode
  - `( )` Desktop & mobile sizes
- Browsers:
  - `(x)` Chromium
  - `( )` Firefox
  - `( )` Safari
- Privacy:
  - `(x)` Commits free of internal data
  - `( )` PR description free of internal data
  - `( )` Logging free of internal data
- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->