### PR TITLE
fix(ci): change concurrency group so we don't trample on each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: run-task-${{ github.workflow }}-${{ inputs.env }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Asana Task: None

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

Orbit equivalent to https://github.com/mbta/glides/pull/3416.

Checklist

<!-- check one from each section with (x) -->

- Appearance **N/A:**
  - `( )` Light & dark mode
  - `( )` Desktop & mobile sizes
- Browsers **N/A:**
  - `( )` Chromium
  - `( )` Firefox
  - `( )` Safari
- Privacy:
  - `(x)` Commits free of internal data
  - `(x)` PR description free of internal data
  - `(x)` Logging free of internal data
- Tests:
  - `( )` Has tests
  - `(x)` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `(x)` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
