### PR TITLE
fix: Spacing bug for Operators header

### DIFF
--- a/js/components/operators.tsx
+++ b/js/components/operators.tsx
@@ -15,7 +15,7 @@ export const Operators = (): ReactElement => {
   const today = useMemo<string>(() => DateTime.now().toISODate(), []);
   const [selectedDate, setSelectedDate] = useState<string>(today);
   return (
-    <main className="text-gray-500 relative top-14">
+    <main className="text-gray-500 relative">
       <section className="max-w-lg mx-auto px-2 py-5">
         <hgroup className="mb-5">
           <h1 className="text-[28px] font-semibold">Operators</h1>


### PR DESCRIPTION
Asana Task: [🪐 📐 Orbit banner warning for stale data](https://app.asana.com/1/15492006741476/project/1200882337457260/task/1210802439052618?focus=true)

Small fix for spacing issue introduced in first PR for this task.

Before:
<img width="375" height="670" alt="image" src="https://github.com/user-attachments/assets/06ea129b-8b07-456d-a4a0-30e2ecd3bd69" />
After:
<img width="375" height="670" alt="image" src="https://github.com/user-attachments/assets/82b57a41-05c0-4342-927b-9e51e00e9666" />

Checklist

<!-- check one from each section with (x) -->

- Appearance:
  - `(X)` Light & dark mode
  - `(X)` Desktop & mobile sizes
- Browsers:
  - `(X)` Chromium
  - `( )` Firefox
  - `( )` Safari
- Privacy:
  - `(X)` Commits free of internal data
  - `(X)` PR description free of internal data
  - `(X)` Logging free of internal data
- Tests:
  - `( )` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `( )` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed
