### PR TITLE
feat: add current location card to orbit sidebar

### DIFF
--- a/js/components/ladderPageShared/sidebar.tsx
+++ b/js/components/ladderPageShared/sidebar.tsx
@@ -93,7 +93,10 @@ const Consist = ({
 
 const CurrentLocation = ({ vehicle }: { vehicle: Vehicle }) => {
   return (
-    <section className="m-5 pt-5 border-t border-gray-300">
+    <section
+      className="m-5 pt-5 border-t border-gray-300"
+      data-testid="current-location-section"
+    >
       <h2 className="text-lg font-semibold uppercase">Current Location</h2>
 
       <div className="flex justify-between mt-3">

--- a/js/components/ladderPageShared/sidebar.tsx
+++ b/js/components/ladderPageShared/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   latestOcsUpdatedAt,
   Vehicle,
 } from "../../models/vehicle";
+import { StopStatus } from "../../models/vehiclePosition";
 import { remapLabels, reorder } from "../../util/consist";
 import { className } from "../../util/dom";
 import { isFeatureEnabled } from "../../util/featureFlags";
@@ -96,7 +97,13 @@ const CurrentLocation = ({ vehicle }: { vehicle: Vehicle }) => {
       <h2 className="text-lg font-semibold uppercase">Current Location</h2>
 
       <div className="flex justify-between mt-3">
-        <div className="flex flex-col justify-between">
+        <div className="flex justify-between">
+          <span>
+            {vehicle.vehiclePosition.stopStatus === StopStatus.StoppedAt ?
+              "Boarding at"
+            : "Next stop"}
+            &nbsp;
+          </span>
           <span className="font-bold">
             {gtfsIdToDisplayName(vehicle.vehiclePosition.stationId) ?? "---"}
           </span>

--- a/js/components/ladderPageShared/sidebar.tsx
+++ b/js/components/ladderPageShared/sidebar.tsx
@@ -98,12 +98,10 @@ const CurrentLocation = ({ vehicle }: { vehicle: Vehicle }) => {
 
       <div className="flex justify-between mt-3">
         <div className="flex justify-between">
-          <span>
-            {vehicle.vehiclePosition.stopStatus === StopStatus.StoppedAt ?
-              "Boarding at"
-            : "Next stop"}
-            &nbsp;
-          </span>
+          {vehicle.vehiclePosition.stopStatus === StopStatus.StoppedAt ?
+            "Boarding at"
+          : "Next stop"}
+          &nbsp;
           <span className="font-bold">
             {gtfsIdToDisplayName(vehicle.vehiclePosition.stationId) ?? "---"}
           </span>
@@ -195,7 +193,10 @@ const NextTrip = ({ vehicle }: { vehicle: Vehicle }) => {
   const nextDepMin = lateForNext(vehicle);
   const showLateBox = nextDepMin !== null && nextDepMin >= 5;
   return (
-    <section className="m-5 pt-5 border-t border-gray-300">
+    <section
+      className="m-5 pt-5 border-t border-gray-300"
+      data-testid="next-trip-section"
+    >
       <h2 className="text-lg font-semibold uppercase">Next Trip</h2>
       {showLateBox && (
         <Late

--- a/js/components/ladderPageShared/sidebar.tsx
+++ b/js/components/ladderPageShared/sidebar.tsx
@@ -1,4 +1,4 @@
-import { formatStationName } from "../../data/stations";
+import { formatStationName, gtfsIdToDisplayName } from "../../data/stations";
 import { dateTimeFormat } from "../../dateTime";
 import { CarId } from "../../models/common";
 import { estimatedArrival } from "../../models/tripUpdate";
@@ -40,6 +40,7 @@ export const SideBar = ({
           vehicle={selection.vehicle}
           searchedCar={selection.searchedCar ?? null}
         />
+        <CurrentLocation vehicle={selection.vehicle} />
         <CurrentTrip vehicle={selection.vehicle} />
         <NextTrip vehicle={selection.vehicle} />
         {isFeatureEnabled("ladder_sidebar_export") ?
@@ -86,6 +87,22 @@ const Consist = ({
         );
       })}
     </div>
+  );
+};
+
+const CurrentLocation = ({ vehicle }: { vehicle: Vehicle }) => {
+  return (
+    <section className="m-5 pt-5 border-t border-gray-300">
+      <h2 className="text-lg font-semibold uppercase">Current Location</h2>
+
+      <div className="flex justify-between mt-3">
+        <div className="flex flex-col justify-between">
+          <span className="font-bold">
+            {gtfsIdToDisplayName(vehicle.vehiclePosition.stationId) ?? "---"}
+          </span>
+        </div>
+      </div>
+    </section>
   );
 };
 

--- a/js/data/stations.ts
+++ b/js/data/stations.ts
@@ -509,6 +509,25 @@ export const formatStationName = (station: string | null | undefined) => {
   );
 };
 
+export const gtfsIdToDisplayName = (
+  gtfsId: string | null | undefined,
+): string | undefined => {
+  if (!gtfsId) return undefined;
+
+  const allStations = Object.values(Stations).flat(2);
+  const station = allStations.find((s) => s.id === gtfsId);
+  if (!station) return undefined;
+
+  if (station.ocs_station_name) {
+    const cleaned = station.ocs_station_name.replace(/\s*\[.*\]$/, "");
+    return formatStationName(cleaned);
+  } else if (station.name) {
+    return station.name;
+  } else {
+    return undefined;
+  }
+};
+
 export const ocsStationNameToGtfs = (ocsStationName: string): string | null => {
   return (
     Object.values(Stations)

--- a/js/data/stations.ts
+++ b/js/data/stations.ts
@@ -519,8 +519,7 @@ export const gtfsIdToDisplayName = (
   if (!station) return undefined;
 
   if (station.ocs_station_name) {
-    const cleaned = station.ocs_station_name.replace(/\s*\[.*\]$/, "");
-    return formatStationName(cleaned);
+    return formatStationName(station.ocs_station_name);
   } else if (station.name) {
     return station.name;
   } else {

--- a/js/test/components/ladderPageShared/sidebar.test.tsx
+++ b/js/test/components/ladderPageShared/sidebar.test.tsx
@@ -1,13 +1,15 @@
 import { SideBar } from "../../../components/ladderPageShared/sidebar";
 import { dateTimeFromISO } from "../../../dateTime";
+import { StopStatus } from "../../../models/vehiclePosition";
 import {
   ocsTripFactory,
   stopTimeUpdateFactory,
   tripUpdateFactory,
   vehicleFactory,
+  vehiclePositionFactory,
 } from "../../helpers/factory";
 import { putEnabledFeatures } from "../../helpers/metadata";
-import { render } from "@testing-library/react";
+import { render, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 describe("sidebar", () => {
@@ -102,8 +104,11 @@ describe("sidebar", () => {
         expect(view.getByText("Braintree")).toBeInTheDocument();
 
         // next trip
-        expect(view.getByText("JFK")).toBeInTheDocument();
-        expect(view.getByText("Kendall")).toBeInTheDocument();
+        const nextSection = view.getByTestId("next-trip-section");
+        const scoped = within(nextSection);
+
+        expect(scoped.getByText(/Next Trip/i)).toBeInTheDocument();
+        expect(scoped.getByText(/JFK/i)).toBeInTheDocument();
       });
 
       test("shows scheduled departure and arrival times if present", () => {
@@ -621,6 +626,28 @@ describe("sidebar", () => {
       );
 
       expect(view.getByTitle("Copy vehicle data (debug)")).toBeInTheDocument();
+    });
+  });
+
+  describe("Current Location section", () => {
+    test("shows 'Boarding at [station]' when stopped at a station", () => {
+      const vehicle = vehicleFactory.build({
+        vehiclePosition: vehiclePositionFactory.build({
+          stationId: "place-pktrm", // Park Street
+          stopStatus: StopStatus.StoppedAt,
+        }),
+        tripUpdate: tripUpdateFactory.build(),
+        ocsTrips: { current: null, next: [] },
+      });
+
+      const view = render(
+        <MemoryRouter>
+          <SideBar selection={{ vehicle }} close={() => {}} />
+        </MemoryRouter>,
+      );
+
+      expect(view.getByText(/Boarding at/i)).toBeInTheDocument();
+      expect(view.getByText(/Park Street/i)).toBeInTheDocument();
     });
   });
 

--- a/js/test/components/ladderPageShared/sidebar.test.tsx
+++ b/js/test/components/ladderPageShared/sidebar.test.tsx
@@ -649,6 +649,50 @@ describe("sidebar", () => {
       expect(view.getByText(/Boarding at/i)).toBeInTheDocument();
       expect(view.getByText(/Park Street/i)).toBeInTheDocument();
     });
+
+    test("shows 'Next stop [station]' when in-transit to a station", () => {
+      const vehicle = vehicleFactory.build({
+        vehiclePosition: vehiclePositionFactory.build({
+          stationId: "place-pktrm",
+          stopStatus: StopStatus.InTransitTo,
+        }),
+        tripUpdate: tripUpdateFactory.build(),
+        ocsTrips: { current: null, next: [] },
+      });
+
+      const view = render(
+        <MemoryRouter>
+          <SideBar selection={{ vehicle }} close={() => {}} />
+        </MemoryRouter>,
+      );
+
+      expect(view.getByText(/Next stop/i)).toBeInTheDocument();
+      expect(view.getByText(/Park Street/i)).toBeInTheDocument();
+    });
+
+    test("falls back to placeholder when station info is missing", () => {
+      const vehicle = vehicleFactory.build({
+        vehiclePosition: vehiclePositionFactory.build({
+          stationId: null,
+          stopStatus: StopStatus.InTransitTo,
+        }),
+        tripUpdate: tripUpdateFactory.build({ stopTimeUpdates: [] }),
+        ocsTrips: { current: null, next: [] },
+      });
+
+      const view = render(
+        <MemoryRouter>
+          <SideBar selection={{ vehicle }} close={() => {}} />
+        </MemoryRouter>,
+      );
+
+      const currentLocationSection = view.getByTestId(
+        "current-location-section",
+      );
+      const scoped = within(currentLocationSection);
+
+      expect(scoped.getByText("---")).toBeInTheDocument();
+    });
   });
 
   describe("Current Trip section", () => {

--- a/js/test/components/ladderPageShared/sidebar.test.tsx
+++ b/js/test/components/ladderPageShared/sidebar.test.tsx
@@ -646,8 +646,13 @@ describe("sidebar", () => {
         </MemoryRouter>,
       );
 
-      expect(view.getByText(/Boarding at/i)).toBeInTheDocument();
-      expect(view.getByText(/Park Street/i)).toBeInTheDocument();
+      const currentLocationSection = view.getByTestId(
+        "current-location-section",
+      );
+      const scoped = within(currentLocationSection);
+
+      expect(scoped.getByText(/Boarding at/i)).toBeInTheDocument();
+      expect(scoped.getByText(/Park Street/i)).toBeInTheDocument();
     });
 
     test("shows 'Next stop [station]' when in-transit to a station", () => {
@@ -666,8 +671,13 @@ describe("sidebar", () => {
         </MemoryRouter>,
       );
 
-      expect(view.getByText(/Next stop/i)).toBeInTheDocument();
-      expect(view.getByText(/Park Street/i)).toBeInTheDocument();
+      const currentLocationSection = view.getByTestId(
+        "current-location-section",
+      );
+      const scoped = within(currentLocationSection);
+
+      expect(scoped.getByText(/Next stop/i)).toBeInTheDocument();
+      expect(scoped.getByText(/Park Street/i)).toBeInTheDocument();
     });
 
     test("falls back to placeholder when station info is missing", () => {


### PR DESCRIPTION
Asana Task: [🍫 Add “current location” card to orbit sidebar](https://app.asana.com/1/15492006741476/project/1200882337457260/task/1216730972771212?focus=true)

<!-- Or consider adding links to:
* Notion
* Slack discussions
* Design files
-->

This adds a "current location" section to the ladder page sidebar. The goal is to get the data in place and match the existing style, with the understanding that the visuals will be updated as part of the upcoming redesign.

This section will show either "boarding at" or "next stop" along with the appropriate station name. In the absence of a station (which should not be possible to click into), it will show hyphens in place of values.

For testing, I pulled in `within` from React Testing Library in order to allow scoping to certain page elements, because some tests were failing due to multiple instances of text appearing after making this change.

Also of note, I noticed some station names come in with an additional suffix (e.g., "Downtown Crossing R" and "Park Street [r]") which I left as is for simplicity and to match the OCS station name we have set.

## Screenshots:
<img width="1463" height="1407" alt="Screenshot 2026-07-31 at 16-22-11 Orbit" src="https://github.com/user-attachments/assets/aa1ae2bc-9452-4c51-bd4e-82e6a331387a" />
<img width="1503" height="1390" alt="Screenshot 2026-07-31 at 16-24-22 Orbit" src="https://github.com/user-attachments/assets/8fac7346-b2f9-48bd-a252-d04dcaac280d" />


Checklist

<!-- check one from each section with (x) -->

- Appearance:
  - `( )` Light & dark mode
  - `(x)` Desktop & mobile sizes
- Browsers:
  - `( )` Chromium
  - `(x)` Firefox
  - `( )` Safari
- Privacy:
  - `(x)` Commits free of internal data
  - `(x)` PR description free of internal data
  - `(x)` Logging free of internal data
- Tests:
  - `(x)` Has tests
  - `( )` Doesn't need tests
  - `( )` Tests deferred (with justification)
- Product/Design sign off:
  - `(x)` Okayed the plan for the feature (e.g. the design files, or the Asana task)
  - `( )` Reviewed the feature as implemented (e.g. on dev-green, or saw screenshots)
  - `( )` No review needed

<!--
* Should this PR be deployed to dev-green for review? If so, add the `deploy-to-dev-green` label.
* Does this review need to be prioritized? If so, add the `important` label.
-->

<!--
Followup Tasks:
(add if needed)

Prompts for followup tasks:
* Does anyone (stakeholders, other teams) need to be told when this work is complete?
* Do we need to be careful about how we deploy this, for technical or product reasons?
* Is there other work that's unblocked by this PR?
* Are there new followup Asana tasks? Link to them.
-->

<!--
Keep Asana up to date.
* After this PR is open, add a link to it from its Asana task and move the task to "Under Review".
* After it's merged, mark the Asana task complete.
-->
